### PR TITLE
Integrate global GLib main loop for libnice support

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -49,6 +49,9 @@ written by
 #include "queue.h"
 #include "cache.h"
 #include "epoll.h"
+#ifdef USE_LIBNICE
+#include <glib.h>
+#endif
 
 class CUDT;
 
@@ -263,6 +266,19 @@ private:
 private:
    CUDTUnited(const CUDTUnited&);
    CUDTUnited& operator=(const CUDTUnited&);
+
+#ifdef USE_LIBNICE
+public:
+   // Accessor for global GLib context used by libnice
+   GMainContext* getNiceContext() { return m_pNiceCtx; }
+
+private:
+   GMainContext* m_pNiceCtx;      // global GLib context for libnice
+   GMainLoop*    m_pNiceLoop;     // main loop running in background thread
+   GThread*      m_pNiceThread;   // thread handle for main loop
+
+   static gpointer libniceLoop(gpointer data);
+#endif
 };
 
 #endif

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -59,6 +59,7 @@ written by
 #ifdef USE_LIBNICE
 #include <nice/agent.h>
 #include <glib.h>
+#include "api.h"
 #endif
 
 #ifdef WIN32
@@ -107,12 +108,11 @@ CChannel::~CChannel()
 void CChannel::open(const sockaddr* addr)
 {
 #ifdef USE_LIBNICE
-   GMainContext* ctx = g_main_context_new();
+   GMainContext* ctx = CUDT::s_UDTUnited.getNiceContext();
    m_pAgent = nice_agent_new(ctx, NICE_COMPATIBILITY_RFC5245);
    m_uStreamID = nice_agent_add_stream(m_pAgent, 1);
    m_uComponentID = 1;
    nice_agent_gather_candidates(m_pAgent, m_uStreamID);
-   g_main_context_unref(ctx);
 #else
    // construct an socket
    m_iSocket = ::socket(m_iIPversion, SOCK_DGRAM, 0);
@@ -218,7 +218,10 @@ void CChannel::close() const
 {
 #ifdef USE_LIBNICE
    if (m_pAgent)
+   {
       g_object_unref(m_pAgent);
+      const_cast<CChannel*>(this)->m_pAgent = NULL;
+   }
 #else
    #ifndef WIN32
       ::close(m_iSocket);


### PR DESCRIPTION
## Summary
- manage a global GLib context and main loop thread in `CUDTUnited`
- start and stop libnice main loop during startup/cleanup
- use the shared context in `CChannel` and ensure libnice agent cleanup

## Testing
- `make USE_LIBNICE=1` *(fails: Package 'nice' not found)*
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68bec28f7c6c832cbda28a184128aaf2