### PR TITLE
Add libnice link flags

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -9,6 +9,7 @@ ifndef arch
 endif
 
 CCFLAGS = -Wall -D$(os) -I../src -finline-functions -O3
+CFLAGS += -I/path/to/libnice/include
 
 ifeq ($(arch), IA32)
    CCFLAGS += -DIA32 #-mcpu=pentiumpro -march=pentiumpro -mmmx -msse
@@ -26,7 +27,7 @@ ifeq ($(arch), SPARC)
    CCFLAGS += -DSPARC
 endif
 
-LDFLAGS = -L../src -ludt -lstdc++ -lpthread -lm
+LDFLAGS = -L../src -L/path/to/libnice/lib -ludt -lnice -lstdc++ -lpthread -lm
 
 ifeq ($(os), UNIX)
    LDFLAGS += -lsocket
@@ -43,7 +44,7 @@ APP = appserver appclient sendfile recvfile test
 all: $(APP)
 
 %.o: %.cpp
-	$(C++) $(CCFLAGS) $< -c
+	$(C++) $(CCFLAGS) $(CFLAGS) $< -c
 
 appserver: appserver.o
 	$(C++) $^ -o $@ $(LDFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,11 @@ endif
 
 CCFLAGS = -fPIC -Wall -Wextra -D$(os) -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden
 
+# Paths and libraries for libnice
+CFLAGS += -I/path/to/libnice/include
+LDFLAGS += -L/path/to/libnice/lib
+LIBS += -lnice
+
 ifeq ($(arch), IA32)
    CCFLAGS += -DIA32
 endif
@@ -36,13 +41,13 @@ DIR = $(shell pwd)
 all: libudt.so libudt.a udt
 
 %.o: %.cpp %.h udt.h
-	$(C++) $(CCFLAGS) $< -c
+	$(C++) $(CCFLAGS) $(CFLAGS) $< -c
 
 libudt.so: $(OBJS)
 ifneq ($(os), OSX)
-	$(C++) -shared -o $@ $^
+	$(C++) -shared $(LDFLAGS) -o $@ $^ $(LIBS)
 else
-	$(C++) -dynamiclib -o libudt.dylib -lstdc++ -lpthread -lm $^
+	$(C++) -dynamiclib $(LDFLAGS) -o libudt.dylib -lstdc++ -lpthread -lm $^ $(LIBS)
 endif
 
 libudt.a: $(OBJS)


### PR DESCRIPTION
## Summary
- link libnice during UDT library build with placeholder include and lib paths
- propagate libnice headers and libs to example applications

## Testing
- `apt-get update` *(fails: The repository ... is not signed)*
- `make` *(fails: cannot find -lnice)*


------
https://chatgpt.com/codex/tasks/task_e_68bed46c09fc832c889046fb06fd354c