### PR TITLE
Introduce IChannel interface for UDP channel abstraction

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -46,7 +46,29 @@ written by
 #include "packet.h"
 
 
-class CChannel
+class IChannel
+{
+public:
+   virtual ~IChannel() {}
+
+   virtual void open(const sockaddr* addr = NULL) = 0;
+   virtual void open(UDPSOCKET udpsock) = 0;
+   virtual void close() const = 0;
+
+   virtual int getSndBufSize() = 0;
+   virtual int getRcvBufSize() = 0;
+   virtual void setSndBufSize(int size) = 0;
+   virtual void setRcvBufSize(int size) = 0;
+
+   virtual void getSockAddr(sockaddr* addr) const = 0;
+   virtual void getPeerAddr(sockaddr* addr) const = 0;
+
+   virtual int sendto(const sockaddr* addr, CPacket& packet) const = 0;
+   virtual int recvfrom(sockaddr* addr, CPacket& packet) const = 0;
+};
+
+
+class CChannel : public IChannel
 {
 public:
    CChannel();

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -487,7 +487,7 @@ CSndQueue::~CSndQueue()
    delete m_pSndUList;
 }
 
-void CSndQueue::init(CChannel* c, CTimer* t)
+void CSndQueue::init(IChannel* c, CTimer* t)
 {
    m_pChannel = c;
    m_pTimer = t;
@@ -937,7 +937,7 @@ CRcvQueue::~CRcvQueue()
    }
 }
 
-void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel* cc, CTimer* t)
+void CRcvQueue::init(int qsize, int payload, int version, int hsize, IChannel* cc, CTimer* t)
 {
    m_iPayloadSize = payload;
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -384,7 +384,7 @@ public:
       // Returned value:
       //    None.
 
-   void init(CChannel* c, CTimer* t);
+   void init(IChannel* c, CTimer* t);
 
       // Functionality:
       //    Send out a packet to a given address.
@@ -407,7 +407,7 @@ private:
 
 private:
    CSndUList* m_pSndUList;		// List of UDT instances for data sending
-   CChannel* m_pChannel;                // The UDP channel for data sending
+   IChannel* m_pChannel;                // The UDP channel for data sending
    CTimer* m_pTimer;			// Timing facility
 
    pthread_mutex_t m_WindowLock;
@@ -444,7 +444,7 @@ public:
       // Returned value:
       //    None.
 
-   void init(int size, int payload, int version, int hsize, CChannel* c, CTimer* t);
+   void init(int size, int payload, int version, int hsize, IChannel* c, CTimer* t);
 
       // Functionality:
       //    Read a packet for a specific UDT socket id.
@@ -470,7 +470,7 @@ private:
 
    CRcvUList* m_pRcvUList;		// List of UDT instances that will read packets from the queue
    CHash* m_pHash;			// Hash table for UDT socket looking up
-   CChannel* m_pChannel;		// UDP channel for receving packets
+   IChannel* m_pChannel;		// UDP channel for receving packets
    CTimer* m_pTimer;			// shared timer with the snd queue
 
    int m_iPayloadSize;                  // packet payload size
@@ -512,7 +512,7 @@ struct CMultiplexer
 {
    CSndQueue* m_pSndQueue;	// The sending queue
    CRcvQueue* m_pRcvQueue;	// The receiving queue
-   CChannel* m_pChannel;	// The UDP channel for sending and receiving
+   IChannel* m_pChannel;	// The UDP channel for sending and receiving
    CTimer* m_pTimer;		// The timer
 
    int m_iPort;			// The UDP port number of this multiplexer


### PR DESCRIPTION
## Summary
- Define an `IChannel` interface exposing UDP channel operations
- Implement `CChannel` via `IChannel`
- Use `IChannel` pointers across queues and multiplexer

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bed47d1c6c832c9ca86a831a11afb2