### PR TITLE
Add libnice pkg-config flags

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -34,6 +34,16 @@ On Windows systems, use the Visual C++ project files in ./win directory.
 
 Note for BSD users, please use GNU Make.
 
+The build requires libnice and its GLib dependency. The Makefiles use
+pkg-config to discover the necessary compiler and linker flags. If
+pkg-config is not available, set the NICE_CFLAGS and NICE_LIBS
+environment variables before invoking make, for example:
+
+    export NICE_CFLAGS='-I/usr/include/nice -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include'
+    export NICE_LIBS='-lnice -lglib-2.0'
+
+Adjust the paths to match your installation locations.
+
 To use UDT in your application:
 Read index.htm in ./doc. The documentation is in HTML format and requires your
 browser to support JavaScript.

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,4 @@
-C++ = g++
+CXX = g++
 
 ifndef os
    os = LINUX
@@ -8,32 +8,41 @@ ifndef arch
    arch = IA32
 endif
 
-CCFLAGS = -Wall -D$(os) -I../src -finline-functions -O3
+CXXFLAGS = -Wall -D$(os) -I../src -finline-functions -O3
+
+PKG_CONFIG ?= pkg-config
+NICE_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)
+NICE_LIBS ?= $(shell $(PKG_CONFIG) --libs nice 2>/dev/null)
+CXXFLAGS += $(NICE_CFLAGS)
+LIBS += $(NICE_LIBS)
+# For systems without pkg-config, set NICE_CFLAGS and NICE_LIBS manually, e.g.:
+# NICE_CFLAGS=-I/usr/include/nice -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
+# NICE_LIBS=-lnice -lglib-2.0
 
 ifeq ($(arch), IA32)
-   CCFLAGS += -DIA32 #-mcpu=pentiumpro -march=pentiumpro -mmmx -msse
+   CXXFLAGS += -DIA32 #-mcpu=pentiumpro -march=pentiumpro -mmmx -msse
 endif
 
 ifeq ($(arch), POWERPC)
-   CCFLAGS += -mcpu=powerpc
+   CXXFLAGS += -mcpu=powerpc
 endif
 
 ifeq ($(arch), IA64)
-   CCFLAGS += -DIA64
+   CXXFLAGS += -DIA64
 endif
 
 ifeq ($(arch), SPARC)
-   CCFLAGS += -DSPARC
+   CXXFLAGS += -DSPARC
 endif
 
-LDFLAGS = -L../src -ludt -lstdc++ -lpthread -lm
+LIBS = -L../src -ludt -lstdc++ -lpthread -lm
 
 ifeq ($(os), UNIX)
-   LDFLAGS += -lsocket
+   LIBS += -lsocket
 endif
 
 ifeq ($(os), SUNOS)
-   LDFLAGS += -lrt -lsocket
+   LIBS += -lrt -lsocket
 endif
 
 DIR = $(shell pwd)
@@ -43,18 +52,18 @@ APP = appserver appclient sendfile recvfile test
 all: $(APP)
 
 %.o: %.cpp
-	$(C++) $(CCFLAGS) $< -c
+	$(CXX) $(CXXFLAGS) $< -c
 
 appserver: appserver.o
-	$(C++) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LIBS)
 appclient: appclient.o
-	$(C++) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LIBS)
 sendfile: sendfile.o
-	$(C++) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LIBS)
 recvfile: recvfile.o
-	$(C++) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LIBS)
 test: test.o
-	$(C++) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LIBS)
 
 clean:
 	rm -f *.o $(APP)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-C++ = g++
+CXX = g++
 
 ifndef os
    os = LINUX
@@ -8,26 +8,35 @@ ifndef arch
    arch = IA32
 endif
 
-CCFLAGS = -fPIC -Wall -Wextra -D$(os) -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden
+CXXFLAGS = -fPIC -Wall -Wextra -D$(os) -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden
+
+PKG_CONFIG ?= pkg-config
+NICE_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)
+NICE_LIBS ?= $(shell $(PKG_CONFIG) --libs nice 2>/dev/null)
+CXXFLAGS += $(NICE_CFLAGS)
+LIBS += $(NICE_LIBS)
+# For systems without pkg-config, set NICE_CFLAGS and NICE_LIBS manually, e.g.:
+# NICE_CFLAGS=-I/usr/include/nice -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
+# NICE_LIBS=-lnice -lglib-2.0
 
 ifeq ($(arch), IA32)
-   CCFLAGS += -DIA32
+   CXXFLAGS += -DIA32
 endif
 
 ifeq ($(arch), POWERPC)
-   CCFLAGS += -mcpu=powerpc
+   CXXFLAGS += -mcpu=powerpc
 endif
 
 ifeq ($(arch), SPARC)
-   CCFLAGS += -DSPARC
+   CXXFLAGS += -DSPARC
 endif
 
 ifeq ($(arch), IA64)
-   CCFLAGS += -DIA64
+   CXXFLAGS += -DIA64
 endif
 
 ifeq ($(arch), AMD64)
-   CCFLAGS += -DAMD64
+   CXXFLAGS += -DAMD64
 endif
 
 OBJS = api.o buffer.o cache.o ccc.o channel.o common.o core.o epoll.o list.o md5.o packet.o queue.o window.o
@@ -36,13 +45,13 @@ DIR = $(shell pwd)
 all: libudt.so libudt.a udt
 
 %.o: %.cpp %.h udt.h
-	$(C++) $(CCFLAGS) $< -c
+	$(CXX) $(CXXFLAGS) $< -c
 
 libudt.so: $(OBJS)
 ifneq ($(os), OSX)
-	$(C++) -shared -o $@ $^
+	$(CXX) -shared -o $@ $^ $(LIBS)
 else
-	$(C++) -dynamiclib -o libudt.dylib -lstdc++ -lpthread -lm $^
+	$(CXX) -dynamiclib -o libudt.dylib -lstdc++ -lpthread -lm $^ $(LIBS)
 endif
 
 libudt.a: $(OBJS)
@@ -56,3 +65,4 @@ clean:
 
 install:
 	export LD_LIBRARY_PATH=$(DIR):$$LD_LIBRARY_PATH
+


### PR DESCRIPTION
## Summary
- add pkg-config based libnice detection in src and app Makefiles
- document manual NICE_CFLAGS/NICE_LIBS for builds without pkg-config

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bee292a0bc832cb5625a7a4360c63f