### PR TITLE
Add libnice-based channel implementation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ ifeq ($(arch), AMD64)
    CXXFLAGS += -DAMD64
 endif
 
-OBJS = api.o buffer.o cache.o ccc.o channel.o common.o core.o epoll.o list.o md5.o packet.o queue.o window.o
+OBJS = api.o buffer.o cache.o ccc.o channel.o nice_channel.o common.o core.o epoll.o list.o md5.o packet.o queue.o window.o
 DIR = $(shell pwd)
 
 all: libudt.so libudt.a udt

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -38,6 +38,8 @@ written by
    Yunhong Gu, last updated 01/27/2011
 *****************************************************************************/
 
+#ifndef USE_LIBNICE
+
 #ifndef WIN32
    #include <netdb.h>
    #include <arpa/inet.h>
@@ -338,3 +340,5 @@ int CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
 
    return packet.getLength();
 }
+
+#endif // !USE_LIBNICE

--- a/src/channel.h
+++ b/src/channel.h
@@ -45,6 +45,10 @@ written by
 #include "udt.h"
 #include "packet.h"
 
+#ifdef USE_LIBNICE
+#include "nice_channel.h"
+typedef CNiceChannel CChannel;
+#else
 
 class CChannel
 {
@@ -167,5 +171,6 @@ private:
    int m_iRcvBufSize;                   // UDP receiving buffer size
 };
 
+#endif // !USE_LIBNICE
 
 #endif

--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -1,0 +1,211 @@
+#ifdef USE_LIBNICE
+
+#include "nice_channel.h"
+#include <cstring>
+#ifndef WIN32
+#include <arpa/inet.h>
+#else
+#include <winsock2.h>
+#endif
+
+CNiceChannel::CNiceChannel():
+m_pAgent(NULL),
+m_iStreamID(0),
+m_iComponentID(0),
+m_pContext(NULL),
+m_pLoop(NULL),
+m_pThread(NULL),
+m_pRecvQueue(NULL),
+m_iSndBufSize(65536),
+m_iRcvBufSize(65536)
+{
+}
+
+CNiceChannel::CNiceChannel(int version):
+m_pAgent(NULL),
+m_iStreamID(0),
+m_iComponentID(0),
+m_pContext(NULL),
+m_pLoop(NULL),
+m_pThread(NULL),
+m_pRecvQueue(NULL),
+m_iSndBufSize(65536),
+m_iRcvBufSize(65536)
+{
+}
+
+CNiceChannel::~CNiceChannel()
+{
+   close();
+}
+
+void CNiceChannel::open(const sockaddr* addr)
+{
+   m_pContext = g_main_context_new();
+   m_pLoop = g_main_loop_new(m_pContext, FALSE);
+   m_pAgent = nice_agent_new(m_pContext, NICE_COMPATIBILITY_RFC5245);
+
+   m_iStreamID = nice_agent_add_stream(m_pAgent, 1);
+   m_iComponentID = 1;
+
+   m_pRecvQueue = g_async_queue_new();
+   nice_agent_attach_recv(m_pAgent, m_iStreamID, m_iComponentID, m_pContext, &CNiceChannel::cb_recv, this);
+
+   m_pThread = g_thread_new("nice-loop", &CNiceChannel::cb_loop, this);
+}
+
+void CNiceChannel::open(UDPSOCKET udpsock)
+{
+   open();
+}
+
+void CNiceChannel::close() const
+{
+   if (m_pAgent)
+   {
+      nice_agent_attach_recv(m_pAgent, m_iStreamID, m_iComponentID, NULL, NULL, NULL);
+   }
+
+   if (m_pLoop)
+      g_main_loop_quit(m_pLoop);
+
+   if (m_pThread)
+      g_thread_join(m_pThread);
+
+   if (m_pAgent)
+      g_object_unref(m_pAgent);
+   if (m_pLoop)
+      g_main_loop_unref(m_pLoop);
+   if (m_pContext)
+      g_main_context_unref(m_pContext);
+   if (m_pRecvQueue)
+      g_async_queue_unref(m_pRecvQueue);
+}
+
+int CNiceChannel::getSndBufSize()
+{
+   return m_iSndBufSize;
+}
+
+int CNiceChannel::getRcvBufSize()
+{
+   return m_iRcvBufSize;
+}
+
+void CNiceChannel::setSndBufSize(int size)
+{
+   m_iSndBufSize = size;
+}
+
+void CNiceChannel::setRcvBufSize(int size)
+{
+   m_iRcvBufSize = size;
+}
+
+void CNiceChannel::getSockAddr(sockaddr* addr) const
+{
+   if (addr)
+      memset(addr, 0, sizeof(sockaddr));
+}
+
+void CNiceChannel::getPeerAddr(sockaddr* addr) const
+{
+   if (addr)
+      memset(addr, 0, sizeof(sockaddr));
+}
+
+int CNiceChannel::sendto(const sockaddr* addr, CPacket& packet) const
+{
+   if (packet.getFlag())
+      for (int i = 0, n = packet.getLength() / 4; i < n; ++ i)
+         *((uint32_t *)packet.m_pcData + i) = htonl(*((uint32_t *)packet.m_pcData + i));
+
+   uint32_t* p = packet.m_nHeader;
+   for (int j = 0; j < 4; ++ j)
+   {
+      *p = htonl(*p);
+      ++ p;
+   }
+
+   int size = CPacket::m_iPktHdrSize + packet.getLength();
+   guint8* buf = (guint8*)g_malloc(size);
+   memcpy(buf, packet.m_nHeader, CPacket::m_iPktHdrSize);
+   memcpy(buf + CPacket::m_iPktHdrSize, packet.m_pcData, packet.getLength());
+
+   int res = nice_agent_send(m_pAgent, m_iStreamID, m_iComponentID, size, (char*)buf);
+   g_free(buf);
+
+   p = packet.m_nHeader;
+   for (int k = 0; k < 4; ++ k)
+   {
+      *p = ntohl(*p);
+      ++ p;
+   }
+
+   if (packet.getFlag())
+   {
+      for (int l = 0, n = packet.getLength() / 4; l < n; ++ l)
+         *((uint32_t *)packet.m_pcData + l) = ntohl(*((uint32_t *)packet.m_pcData + l));
+   }
+
+   return res;
+}
+
+int CNiceChannel::recvfrom(sockaddr* addr, CPacket& packet) const
+{
+   if (addr)
+      memset(addr, 0, sizeof(sockaddr));
+
+   GByteArray* arr = (GByteArray*)g_async_queue_pop(m_pRecvQueue);
+   if (NULL == arr)
+      return -1;
+
+   int size = arr->len;
+   if (size < CPacket::m_iPktHdrSize)
+   {
+      g_byte_array_unref(arr);
+      packet.setLength(-1);
+      return -1;
+   }
+
+   memcpy(packet.m_nHeader, arr->data, CPacket::m_iPktHdrSize);
+   memcpy(packet.m_pcData, arr->data + CPacket::m_iPktHdrSize, size - CPacket::m_iPktHdrSize);
+   g_byte_array_unref(arr);
+
+   packet.setLength(size - CPacket::m_iPktHdrSize);
+
+   uint32_t* p = packet.m_nHeader;
+   for (int i = 0; i < 4; ++ i)
+   {
+      *p = ntohl(*p);
+      ++ p;
+   }
+
+   if (packet.getFlag())
+   {
+      for (int j = 0, n = packet.getLength() / 4; j < n; ++ j)
+         *((uint32_t *)packet.m_pcData + j) = ntohl(*((uint32_t *)packet.m_pcData + j));
+   }
+
+   return packet.getLength();
+}
+
+void CNiceChannel::cb_recv(NiceAgent* agent, guint stream_id, guint component_id,
+                           guint len, gchar* buf, gpointer data)
+{
+   CNiceChannel* self = (CNiceChannel*)data;
+   if (!self->m_pRecvQueue)
+      return;
+   GByteArray* arr = g_byte_array_sized_new(len);
+   g_byte_array_append(arr, (guint8*)buf, len);
+   g_async_queue_push(self->m_pRecvQueue, arr);
+}
+
+gpointer CNiceChannel::cb_loop(gpointer data)
+{
+   CNiceChannel* self = (CNiceChannel*)data;
+   g_main_loop_run(self->m_pLoop);
+   return NULL;
+}
+
+#endif

--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -1,0 +1,94 @@
+/*****************************************************************************
+Copyright (c) 2001 - 2011, The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the
+  above copyright notice, this list of conditions
+  and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the University of Illinois
+  nor the names of its contributors may be used to
+  endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS"
+IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/*****************************************************************************
+written by
+   ChatGPT
+*****************************************************************************/
+
+#ifndef __UDT_NICE_CHANNEL_H__
+#define __UDT_NICE_CHANNEL_H__
+
+#ifdef USE_LIBNICE
+
+#include "udt.h"
+#include "packet.h"
+
+#include <nice/agent.h>
+#include <glib.h>
+#include <queue>
+
+class CNiceChannel
+{
+public:
+   CNiceChannel();
+   CNiceChannel(int version);
+   ~CNiceChannel();
+
+   void open(const sockaddr* addr = NULL);
+   void open(UDPSOCKET udpsock);
+   void close() const;
+
+   int getSndBufSize();
+   int getRcvBufSize();
+   void setSndBufSize(int size);
+   void setRcvBufSize(int size);
+   void getSockAddr(sockaddr* addr) const;
+   void getPeerAddr(sockaddr* addr) const;
+
+   int sendto(const sockaddr* addr, CPacket& packet) const;
+   int recvfrom(sockaddr* addr, CPacket& packet) const;
+
+private:
+   static void cb_recv(NiceAgent* agent, guint stream_id, guint component_id,
+                       guint len, gchar* buf, gpointer data);
+   static gpointer cb_loop(gpointer data);
+
+private:
+   NiceAgent*     m_pAgent;
+   guint          m_iStreamID;
+   guint          m_iComponentID;
+   GMainContext*  m_pContext;
+   GMainLoop*     m_pLoop;
+   GThread*       m_pThread;
+   GAsyncQueue*   m_pRecvQueue;
+
+   int            m_iSndBufSize;
+   int            m_iRcvBufSize;
+};
+
+#endif // USE_LIBNICE
+
+#endif


### PR DESCRIPTION
## Summary
- Add `CNiceChannel` wrapping libnice's `NiceAgent` with internal receive queue and send/receive helpers
- Allow switching between UDP and libnice via `USE_LIBNICE` macro
- Include `nice_channel` in build outputs

## Testing
- `make -C src`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bee4241ba4832cb233ca6e9416f915