### PR TITLE
Manage GLib loop lifecycle in CNiceChannel

### DIFF
--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -59,7 +59,7 @@ public:
 
    void open(const sockaddr* addr = NULL);
    void open(UDPSOCKET udpsock);
-   void close() const;
+   void close();
 
    int getSndBufSize();
    int getRcvBufSize();


### PR DESCRIPTION
## Summary
- Create a dedicated GLib `GMainContext` and `GMainLoop` when opening a NICE channel
- Spawn a loop thread running `g_main_loop_run` and surface failures through `CUDTException`
- Ensure `close` stops the loop, joins the thread, and releases all GLib resources
- Include `nice/agent.h` directly in the NICE channel implementation

## Testing
- `make`
- `g++ -DUSE_LIBNICE -I./src -c src/nice_channel.cpp` *(fails: nice/agent.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bee61ba2fc832cb72028ad313c8435