### PR TITLE
Ensure ICE candidates are gathered before retrieval

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2180,6 +2180,7 @@ int CUDT::getICEInfo(UDTSOCKET u, std::string& ufrag, std::string& pwd,
    try
    {
        CUDT* udt = s_UDTUnited.lookup(u);
+       udt->m_pSndQueue->m_pChannel->waitForCandidates();
        int r1 = udt->m_pSndQueue->m_pChannel->getLocalCredentials(ufrag, pwd);
        int r2 = udt->m_pSndQueue->m_pChannel->getLocalCandidates(candidates);
        return (r1 < 0 || r2 < 0) ? ERROR : 0;

--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -89,6 +89,9 @@ public:
    // Provide remote candidates (each in SDP attribute format) prior to checks.
    int setRemoteCandidates(const std::vector<std::string>& candidates);
 
+   // Block until candidate gathering has completed.
+   void waitForCandidates();
+
 private:
    static void cb_recv(NiceAgent* agent, guint stream_id, guint component_id,
                        guint len, gchar* buf, gpointer data);
@@ -96,6 +99,8 @@ private:
    static void cb_state_changed(NiceAgent* agent, guint stream_id,
                                guint component_id, guint state,
                                gpointer data);
+   static void cb_candidate_gathering_done(NiceAgent* agent, guint stream_id,
+                                           gpointer data);
 
 private:
    NiceAgent*     m_pAgent;
@@ -113,6 +118,7 @@ private:
    GCond          m_StateCond;
    bool           m_bConnected;
    bool           m_bFailed;
+   bool           m_bGatheringDone;
 };
 
 #endif // USE_LIBNICE


### PR DESCRIPTION
## Summary
- Trigger ICE candidate gathering after initializing NiceAgent and track completion via signal callback
- Add `waitForCandidates` to block until candidate gathering completes
- Wait for candidate gathering in `getICEInfo` before returning credentials and candidates

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bef54f4510832c9757b1165ede6ee3