### PR TITLE
Cache ICE candidate addresses and relax peer validation

### DIFF
--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -123,6 +123,8 @@ private:
    bool           m_bFailed;
    bool           m_bGatheringDone;
    bool           m_bControlling;
+   mutable sockaddr_storage m_SockAddr;
+   mutable sockaddr_storage m_PeerAddr;
 };
 
 #endif // USE_LIBNICE

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1043,7 +1043,13 @@ void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel* c
       {
          if (NULL != (u = self->m_pHash->lookup(id)))
          {
-            if (CIPAddress::ipcmp(addr, u->m_pPeerAddr, u->m_iIPversion))
+            if (
+#ifdef USE_LIBNICE
+                true
+#else
+                CIPAddress::ipcmp(addr, u->m_pPeerAddr, u->m_iIPversion)
+#endif
+               )
             {
                if (u->m_bConnected && !u->m_bBroken && !u->m_bClosing)
                {


### PR DESCRIPTION
## Summary
- Cache selected ICE candidate pair in `CNiceChannel` and expose addresses via `getSockAddr`/`getPeerAddr`
- Skip address comparison in `CRcvQueue::worker` when built with libnice
- Compute SYN cookie in `listen()` without requiring the real peer IP/port

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68befe588b7c832ca49b74d3fb1db5d4