### PR TITLE
Use pkg-config fallback and integrate NICE libs

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -11,10 +11,12 @@ endif
 CXXFLAGS = -Wall -D$(os) -I../src -finline-functions -O3
 
 PKG_CONFIG ?= pkg-config
-NICE_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)
+NICE_CFLAGS := $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)
+ifneq ($(findstring glib-2.0,$(NICE_CFLAGS)),glib-2.0)
+NICE_CFLAGS := $(shell $(PKG_CONFIG) --cflags nice glib-2.0 2>/dev/null)
+endif
 NICE_LIBS ?= $(shell $(PKG_CONFIG) --libs nice 2>/dev/null)
 CXXFLAGS += $(NICE_CFLAGS)
-LIBS += $(NICE_LIBS)
 # For systems without pkg-config, set NICE_CFLAGS and NICE_LIBS manually, e.g.:
 # NICE_CFLAGS=-I/usr/include/nice -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
 # NICE_LIBS=-lnice -lglib-2.0
@@ -35,7 +37,7 @@ ifeq ($(arch), SPARC)
    CXXFLAGS += -DSPARC
 endif
 
-LIBS = -L../src -ludt -lstdc++ -lpthread -lm
+LIBS = -L../src -ludt -lstdc++ -lpthread -lm $(NICE_LIBS)
 
 ifeq ($(os), UNIX)
    LIBS += -lsocket

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,10 @@ endif
 CXXFLAGS = -fPIC -Wall -Wextra -D$(os) -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden
 
 PKG_CONFIG ?= pkg-config
-NICE_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)
+NICE_CFLAGS := $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)
+ifneq ($(findstring glib-2.0,$(NICE_CFLAGS)),glib-2.0)
+NICE_CFLAGS := $(shell $(PKG_CONFIG) --cflags nice glib-2.0 2>/dev/null)
+endif
 NICE_LIBS ?= $(shell $(PKG_CONFIG) --libs nice 2>/dev/null)
 CXXFLAGS += $(NICE_CFLAGS)
 LIBS += $(NICE_LIBS)


### PR DESCRIPTION
## Summary
- use pkg-config to derive NICE cflags with glib-2.0 fallback
- link client applications against libnice by default
- propagate same pkg-config logic in src Makefile

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e0c9af8832cb6a738dc0f1632a7