### PR TITLE
refactor error code definitions

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -649,44 +649,6 @@ void CUDTException::clear()
    m_iErrno = 0;
 }
 
-const int CUDTException::SUCCESS = 0;
-const int CUDTException::ECONNSETUP = 1000;
-const int CUDTException::ENOSERVER = 1001;
-const int CUDTException::ECONNREJ = 1002;
-const int CUDTException::ESOCKFAIL = 1003;
-const int CUDTException::ESECFAIL = 1004;
-const int CUDTException::ECONNFAIL = 2000;
-const int CUDTException::ECONNLOST = 2001;
-const int CUDTException::ENOCONN = 2002;
-const int CUDTException::ERESOURCE = 3000;
-const int CUDTException::ETHREAD = 3001;
-const int CUDTException::ENOBUF = 3002;
-const int CUDTException::EFILE = 4000;
-const int CUDTException::EINVRDOFF = 4001;
-const int CUDTException::ERDPERM = 4002;
-const int CUDTException::EINVWROFF = 4003;
-const int CUDTException::EWRPERM = 4004;
-const int CUDTException::EINVOP = 5000;
-const int CUDTException::EBOUNDSOCK = 5001;
-const int CUDTException::ECONNSOCK = 5002;
-const int CUDTException::EINVPARAM = 5003;
-const int CUDTException::EINVSOCK = 5004;
-const int CUDTException::EUNBOUNDSOCK = 5005;
-const int CUDTException::ENOLISTEN = 5006;
-const int CUDTException::ERDVNOSERV = 5007;
-const int CUDTException::ERDVUNBOUND = 5008;
-const int CUDTException::ESTREAMILL = 5009;
-const int CUDTException::EDGRAMILL = 5010;
-const int CUDTException::EDUPLISTEN = 5011;
-const int CUDTException::ELARGEMSG = 5012;
-const int CUDTException::EINVPOLLID = 5013;
-const int CUDTException::EASYNCFAIL = 6000;
-const int CUDTException::EASYNCSND = 6001;
-const int CUDTException::EASYNCRCV = 6002;
-const int CUDTException::ETIMEOUT = 6003;
-const int CUDTException::EPEERERR = 7000;
-const int CUDTException::EUNKNOWN = -1;
-
 
 //
 bool CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver)

--- a/src/udt.h
+++ b/src/udt.h
@@ -251,43 +251,46 @@ private:
    std::string m_strDebug;	// debug information, set to the original place that causes the error
 
 public: // Error Code
-   static const int SUCCESS;
-   static const int ECONNSETUP;
-   static const int ENOSERVER;
-   static const int ECONNREJ;
-   static const int ESOCKFAIL;
-   static const int ESECFAIL;
-   static const int ECONNFAIL;
-   static const int ECONNLOST;
-   static const int ENOCONN;
-   static const int ERESOURCE;
-   static const int ETHREAD;
-   static const int ENOBUF;
-   static const int EFILE;
-   static const int EINVRDOFF;
-   static const int ERDPERM;
-   static const int EINVWROFF;
-   static const int EWRPERM;
-   static const int EINVOP;
-   static const int EBOUNDSOCK;
-   static const int ECONNSOCK;
-   static const int EINVPARAM;
-   static const int EINVSOCK;
-   static const int EUNBOUNDSOCK;
-   static const int ENOLISTEN;
-   static const int ERDVNOSERV;
-   static const int ERDVUNBOUND;
-   static const int ESTREAMILL;
-   static const int EDGRAMILL;
-   static const int EDUPLISTEN;
-   static const int ELARGEMSG;
-   static const int EINVPOLLID;
-   static const int EASYNCFAIL;
-   static const int EASYNCSND;
-   static const int EASYNCRCV;
-   static const int ETIMEOUT;
-   static const int EPEERERR;
-   static const int EUNKNOWN;
+   enum ErrorCode
+   {
+      SUCCESS = 0,
+      ECONNSETUP = 1000,
+      ENOSERVER = 1001,
+      ECONNREJ = 1002,
+      ESOCKFAIL = 1003,
+      ESECFAIL = 1004,
+      ECONNFAIL = 2000,
+      ECONNLOST = 2001,
+      ENOCONN = 2002,
+      ERESOURCE = 3000,
+      ETHREAD = 3001,
+      ENOBUF = 3002,
+      EFILE = 4000,
+      EINVRDOFF = 4001,
+      ERDPERM = 4002,
+      EINVWROFF = 4003,
+      EWRPERM = 4004,
+      EINVOP = 5000,
+      EBOUNDSOCK = 5001,
+      ECONNSOCK = 5002,
+      EINVPARAM = 5003,
+      EINVSOCK = 5004,
+      EUNBOUNDSOCK = 5005,
+      ENOLISTEN = 5006,
+      ERDVNOSERV = 5007,
+      ERDVUNBOUND = 5008,
+      ESTREAMILL = 5009,
+      EDGRAMILL = 5010,
+      EDUPLISTEN = 5011,
+      ELARGEMSG = 5012,
+      EINVPOLLID = 5013,
+      EASYNCFAIL = 6000,
+      EASYNCSND = 6001,
+      EASYNCRCV = 6002,
+      ETIMEOUT = 6003,
+      EPEERERR = 7000,
+      EUNKNOWN = -1
+   };
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- embed UDT error codes directly in `CUDTException` via an enum
- drop no-longer-needed error code definitions from `common.cpp`

## Testing
- `make -j1`

------
https://chatgpt.com/codex/tasks/task_e_68c0297a40d0832c9794785cb5b180d8