### PR TITLE
Export error constants

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -65,8 +65,8 @@ CUDTUnited CUDT::s_UDTUnited;
 const UDTSOCKET CUDT::INVALID_SOCK = -1;
 const int CUDT::ERROR = -1;
 
-const UDTSOCKET UDT::INVALID_SOCK = CUDT::INVALID_SOCK;
-const int UDT::ERROR = CUDT::ERROR;
+UDT_API const UDTSOCKET UDT::INVALID_SOCK = CUDT::INVALID_SOCK;
+UDT_API const int UDT::ERROR = CUDT::ERROR;
 
 const int32_t CSeqNo::m_iSeqNoTH = 0x3FFFFFFF;
 const int32_t CSeqNo::m_iMaxSeqNo = 0x7FFFFFFF;


### PR DESCRIPTION
## Summary
- export `UDT::INVALID_SOCK` and `UDT::ERROR` constants via `UDT_API` to ensure visibility across build types

## Testing
- `make`
- `g++ -E -P -DWIN32 -DUDT_EXPORTS -I/workspace/poleis-nice -I/tmp/wininclude /tmp/udt_api_test.cpp | tail -n 5`
- `g++ -E -P -DWIN32 -D__MINGW__ -I/workspace/poleis-nice -I/tmp/wininclude /tmp/udt_api_test.cpp | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c02d1f8f28832caf64f9ef6a031177