### PR TITLE
Use standard Linux check for epoll implementation

### DIFF
--- a/src/epoll.cpp
+++ b/src/epoll.cpp
@@ -38,7 +38,7 @@ written by
    Yunhong Gu, last updated 01/01/2011
 *****************************************************************************/
 
-#ifdef LINUX
+#ifdef __linux__
    #include <sys/epoll.h>
    #include <unistd.h>
 #endif
@@ -70,7 +70,7 @@ int CEPoll::create()
 
    int localid = 0;
 
-   #ifdef LINUX
+   #ifdef __linux__
    localid = epoll_create(1024);
    if (localid < 0)
       throw CUDTException(-1, 0, errno);
@@ -115,7 +115,7 @@ int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
    if (p == m_mPolls.end())
       throw CUDTException(5, 13);
 
-#ifdef LINUX
+#ifdef __linux__
    epoll_event ev;
    memset(&ev, 0, sizeof(epoll_event));
 
@@ -165,7 +165,7 @@ int CEPoll::remove_ssock(const int eid, const SYSSOCKET& s)
    if (p == m_mPolls.end())
       throw CUDTException(5, 13);
 
-#ifdef LINUX
+#ifdef __linux__
    epoll_event ev;  // ev is ignored, for compatibility with old Linux kernel only.
    if (::epoll_ctl(p->second.m_iLocalID, EPOLL_CTL_DEL, s, &ev) < 0)
       throw CUDTException();
@@ -227,7 +227,7 @@ int CEPoll::wait(const int eid, set<UDTSOCKET>* readfds, set<UDTSOCKET>* writefd
 
       if (lrfds || lwfds)
       {
-         #ifdef LINUX
+         #ifdef __linux__
          const int max_events = p->second.m_sLocals.size();
          epoll_event ev[max_events];
          int nfds = ::epoll_wait(p->second.m_iLocalID, ev, max_events, 0);
@@ -308,7 +308,7 @@ int CEPoll::release(const int eid)
    if (i == m_mPolls.end())
       throw CUDTException(5, 13);
 
-   #ifdef LINUX
+   #ifdef __linux__
    // release local/system epoll descriptor
    ::close(i->second.m_iLocalID);
    #endif


### PR DESCRIPTION
## Summary
- Guard epoll-specific code with `#ifdef __linux__` instead of the custom `LINUX` macro to ensure correct platform detection.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c02e5b5af0832cb8842bf885b9ca26