### PR TITLE
Add assignment operator for CUDTException

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -418,6 +418,18 @@ m_strMsg()
 {
 }
 
+UDT_API CUDTException& CUDTException::operator=(const CUDTException& e)
+{
+   if (this != &e)
+   {
+      m_iMajor = e.m_iMajor;
+      m_iMinor = e.m_iMinor;
+      m_iErrno = e.m_iErrno;
+      m_strMsg.clear();
+   }
+   return *this;
+}
+
 UDT_API CUDTException::~CUDTException()
 {
 }

--- a/src/udt.h
+++ b/src/udt.h
@@ -203,6 +203,7 @@ class UDT_API CUDTException
 public:
    CUDTException(int major = 0, int minor = 0, int err = -1);
    CUDTException(const CUDTException& e);
+   CUDTException& operator=(const CUDTException&);
    virtual ~CUDTException();
 
       // Functionality:


### PR DESCRIPTION
## Summary
- declare copy assignment operator for `CUDTException`
- implement operator to copy error fields and reset message

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c02f2af380832cabed530136920159