### PR TITLE
Use Windows HANDLE for timer event objects

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -64,8 +64,8 @@ uint64_t CTimer::s_ullCPUFrequency = CTimer::readCPUFrequency();
    pthread_mutex_t CTimer::m_EventLock = PTHREAD_MUTEX_INITIALIZER;
    pthread_cond_t CTimer::m_EventCond = PTHREAD_COND_INITIALIZER;
 #else
-   pthread_mutex_t CTimer::m_EventLock = CreateMutex(NULL, false, NULL);
-   pthread_cond_t CTimer::m_EventCond = CreateEvent(NULL, false, false, NULL);
+   HANDLE CTimer::m_EventLock = CreateMutex(NULL, false, NULL);
+   HANDLE CTimer::m_EventCond = CreateEvent(NULL, false, false, NULL);
 #endif
 
 CTimer::CTimer():


### PR DESCRIPTION
## Summary
- Use `HANDLE` for `CTimer` event lock and event condition on Windows to match `common.h`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c0328f27fc832c9ef7497ce21e70b5