### PR TITLE
Define UDT_EXPORTS during library build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ foreach(tgt udt udt_static)
       $<INSTALL_INTERFACE:include>
   )
   target_compile_options(${tgt} PRIVATE -fPIC -Wall -Wextra -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden)
+  target_compile_definitions(${tgt} PRIVATE UDT_EXPORTS)
 endforeach()
 
 if(NICE_FOUND)

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ ifndef arch
    arch = IA32
 endif
 
-CXXFLAGS = -fPIC -Wall -Wextra -D$(os) -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden
+CXXFLAGS = -fPIC -Wall -Wextra -D$(os) -DUDT_EXPORTS -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden
 
 PKG_CONFIG ?= pkg-config
 NICE_CFLAGS := $(shell $(PKG_CONFIG) --cflags nice 2>/dev/null)


### PR DESCRIPTION
## Summary
- Ensure library targets compile with `UDT_EXPORTS` so `UDT_API` uses `__declspec(dllexport)` when building on Windows.
- Propagate `UDT_EXPORTS` through both CMake and Makefile build systems.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c0341bce88832cac140e259f83f1fd