### PR TITLE
Remove UDT_API from UDT constants

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -65,8 +65,8 @@ CUDTUnited CUDT::s_UDTUnited;
 const UDTSOCKET CUDT::INVALID_SOCK = -1;
 const int CUDT::ERROR = -1;
 
-UDT_API const UDTSOCKET UDT::INVALID_SOCK = CUDT::INVALID_SOCK;
-UDT_API const int UDT::ERROR = CUDT::ERROR;
+const UDTSOCKET UDT::INVALID_SOCK = CUDT::INVALID_SOCK;
+const int UDT::ERROR = CUDT::ERROR;
 
 const int32_t CSeqNo::m_iSeqNoTH = 0x3FFFFFFF;
 const int32_t CSeqNo::m_iMaxSeqNo = 0x7FFFFFFF;


### PR DESCRIPTION
## Summary
- Remove UDT_API from INVALID_SOCK and ERROR definitions so only header declarations export symbols
## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c0369757f0832c8e216d937deb33e4