### PR TITLE
Ensure consistent type in CGuard mutex comparison

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -343,7 +343,7 @@ CGuard::~CGuard()
 #else
 CGuard::~CGuard()
 {
-   if (WAIT_FAILED != m_iLocked)
+   if (WAIT_FAILED != static_cast<DWORD>(m_iLocked))
       ReleaseMutex(m_Mutex);
 }
 #endif


### PR DESCRIPTION
## Summary
- Cast `m_iLocked` to `DWORD` when comparing against `WAIT_FAILED` in `CGuard` destructor to avoid signed/unsigned mismatch

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68c037d67160832c8964e934412fec53