### PR TITLE
Handle events for system sockets on non-Linux platforms

### DIFF
--- a/src/epoll.h
+++ b/src/epoll.h
@@ -56,6 +56,8 @@ struct CEPollDesc
 
    int m_iLocalID;                           // local system epoll ID
    std::set<SYSSOCKET> m_sLocals;            // set of local (non-UDT) descriptors
+   std::set<SYSSOCKET> m_sLocalsOut;         // local descriptors waiting for write events
+   std::set<SYSSOCKET> m_sLocalsIn;          // local descriptors waiting for read events
 
    std::set<UDTSOCKET> m_sUDTWrites;         // UDT sockets ready for write
    std::set<UDTSOCKET> m_sUDTReads;          // UDT sockets ready for read


### PR DESCRIPTION
## Summary
- Track requested read/write events for system sockets.
- Honor system socket event masks during wait on non-Linux builds.

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68c03865257c832c8edb9f7853a0a4f7