### PR TITLE
Link Windows targets against WinSock

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,12 @@ add_library(udt SHARED ${SOURCES})
 add_library(udt_static STATIC ${SOURCES})
 set_target_properties(udt_static PROPERTIES OUTPUT_NAME udt)
 
+if(WIN32)
+  foreach(tgt udt udt_static)
+    target_link_libraries(${tgt} PRIVATE ws2_32)
+  endforeach()
+endif()
+
 # Common include directories for public headers
 foreach(tgt udt udt_static)
   target_include_directories(${tgt}


### PR DESCRIPTION
## Summary
- Link both shared and static UDT targets against `ws2_32` on Windows to resolve missing WinSock symbols.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c0c50bce38832c938cd5b41b14ae58