### PR TITLE
Fix CreateThread argument order

### DIFF
--- a/app/test.cpp
+++ b/app/test.cpp
@@ -693,8 +693,8 @@ DWORD WINAPI Test_4_Cli(LPVOID)
 
    for (vector<HANDLE>::iterator i = cli_threads.begin(); i != cli_threads.end(); ++ i)
    {
-      *i = CreateThread(NULL, 0, NULL, start_and_destroy_clients, 0, NULL);
-   }
+      *i = CreateThread(NULL, 0, start_and_destroy_clients, NULL, 0, NULL);
+      }
 
    for (vector<HANDLE>::iterator i = cli_threads.begin(); i != cli_threads.end(); ++ i)
    {


### PR DESCRIPTION
## Summary
- correct CreateThread call in Test_4_Cli to use start_and_destroy_clients as the thread function and pass NULL as argument

## Testing
- `make -C app test` *(fails: /usr/bin/ld: cannot find -ludt: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c87facc0832cac653cda53c95859