### PR TITLE
Use udt_static for Windows builds and support optional dll copy

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,14 +8,23 @@ set(APP_SOURCES
     appniceclient.cpp
 )
 
+option(UDT_COPY_DLL "Copy udt.dll beside executables for dynamic linking" OFF)
+
 find_package(Threads)
 
 foreach(src ${APP_SOURCES})
   get_filename_component(exe ${src} NAME_WE)
   add_executable(${exe} ${src})
-  target_link_libraries(${exe} PRIVATE udt Threads::Threads m)
   if(WIN32)
-    target_link_libraries(${exe} PRIVATE ws2_32)
+    target_link_libraries(${exe} PRIVATE udt_static Threads::Threads m ws2_32)
+    if(UDT_COPY_DLL)
+      add_custom_command(TARGET ${exe} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:udt>" "$<TARGET_FILE_DIR:${exe}>"
+      )
+    endif()
+  else()
+    target_link_libraries(${exe} PRIVATE udt Threads::Threads m)
   endif()
   target_compile_options(${exe} PRIVATE -Wall -finline-functions -O3)
   target_include_directories(${exe} PRIVATE ${CMAKE_SOURCE_DIR}/src)


### PR DESCRIPTION
## Summary
- Link Windows executables against `udt_static`
- Allow optional post-build copy of `udt.dll`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68c0cb4317d0832c9d24f9ad3a444331