### PR TITLE
Define macro for static UDT on Windows

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -17,6 +17,7 @@ foreach(src ${APP_SOURCES})
   add_executable(${exe} ${src})
   if(WIN32)
     target_link_libraries(${exe} PRIVATE udt_static Threads::Threads m ws2_32)
+    target_compile_definitions(${exe} PRIVATE UDT_EXPORTS)
     if(UDT_COPY_DLL)
       add_custom_command(TARGET ${exe} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different


### PR DESCRIPTION
## Summary
- Ensure Windows app executables linked with `udt_static` define `UDT_EXPORTS` so `udt.h` avoids `__declspec(dllimport)` and fixes unresolved `__imp__` symbols

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68c0cc97af28832c9d11258abc847116