### PR TITLE
Refactor CNiceChannel to use packet header accessors

### DIFF
--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -217,7 +217,7 @@ int CNiceChannel::sendto(const sockaddr* addr, CPacket& packet) const
       for (int i = 0, n = packet.getLength() / 4; i < n; ++ i)
          *((uint32_t *)packet.m_pcData + i) = htonl(*((uint32_t *)packet.m_pcData + i));
 
-   uint32_t* p = packet.m_nHeader;
+   uint32_t* p = packet.header();
    for (int j = 0; j < 4; ++ j)
    {
       *p = htonl(*p);
@@ -226,13 +226,13 @@ int CNiceChannel::sendto(const sockaddr* addr, CPacket& packet) const
 
    int size = CPacket::m_iPktHdrSize + packet.getLength();
    guint8* buf = (guint8*)g_malloc(size);
-   memcpy(buf, packet.m_nHeader, CPacket::m_iPktHdrSize);
+   memcpy(buf, packet.header(), CPacket::m_iPktHdrSize);
    memcpy(buf + CPacket::m_iPktHdrSize, packet.m_pcData, packet.getLength());
 
    int res = nice_agent_send(m_pAgent, m_iStreamID, m_iComponentID, size, (char*)buf);
    g_free(buf);
 
-   p = packet.m_nHeader;
+   p = packet.header();
    for (int k = 0; k < 4; ++ k)
    {
       *p = ntohl(*p);
@@ -298,13 +298,13 @@ int CNiceChannel::recvfrom(sockaddr* addr, CPacket& packet) const
       return -1;
    }
 
-   memcpy(packet.m_nHeader, arr->data, CPacket::m_iPktHdrSize);
+   packet.setHeader(reinterpret_cast<const uint32_t*>(arr->data));
    memcpy(packet.m_pcData, arr->data + CPacket::m_iPktHdrSize, size - CPacket::m_iPktHdrSize);
    g_byte_array_unref(arr);
 
    packet.setLength(size - CPacket::m_iPktHdrSize);
 
-   uint32_t* p = packet.m_nHeader;
+   uint32_t* p = packet.header();
    for (int i = 0; i < 4; ++ i)
    {
       *p = ntohl(*p);

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -354,6 +354,21 @@ CPacket* CPacket::clone() const
    return pkt;
 }
 
+uint32_t* CPacket::header()
+{
+   return m_nHeader;
+}
+
+const uint32_t* CPacket::header() const
+{
+   return m_nHeader;
+}
+
+void CPacket::setHeader(const uint32_t* h)
+{
+   memcpy(m_nHeader, h, m_iPktHdrSize);
+}
+
 CHandShake::CHandShake():
 m_iVersion(0),
 m_iType(0),

--- a/src/packet.h
+++ b/src/packet.h
@@ -193,6 +193,25 @@ public:
 
    CPacket* clone() const;
 
+      // Functionality:
+      //    Provide access to the packet header buffer.
+      // Parameters:
+      //    None.
+      // Returned value:
+      //    Pointer to the beginning of the header.
+
+   uint32_t* header();
+   const uint32_t* header() const;
+
+      // Functionality:
+      //    Copy data into the packet header.
+      // Parameters:
+      //    0) [in] h: pointer to data to copy from.
+      // Returned value:
+      //    None.
+
+   void setHeader(const uint32_t* h);
+
 protected:
    uint32_t m_nHeader[4];               // The 128-bit header field
    iovec m_PacketVector[2];             // The 2-demension vector of UDT packet [header, data]


### PR DESCRIPTION
## Summary
- add header accessor and setter in `CPacket`
- refactor CNiceChannel `sendto`/`recvfrom` to use `CPacket` accessors instead of touching `m_nHeader`

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make -C src`

------
https://chatgpt.com/codex/tasks/task_e_68c0d54a5574832ca54c9857a20afd0e