### PR TITLE
Simplify remote ICE info input for NICE examples

### DIFF
--- a/app/appniceclient.cpp
+++ b/app/appniceclient.cpp
@@ -52,20 +52,18 @@ int main(int argc, char* argv[])
    for (vector<string>::iterator it = candidates.begin(); it != candidates.end(); ++it)
       cout << *it << endl;
 
+   cout << "Paste remote ICE info (username fragment, password, candidates) and end with an empty line:" << endl;
    string rem_ufrag, rem_pwd;
-   cout << "Enter remote ICE username fragment: ";
    getline(cin, rem_ufrag);
-   cout << "Enter remote ICE password: ";
    getline(cin, rem_pwd);
-   cout << "Enter number of remote candidates: ";
-   int n = 0;
-   cin >> n;
-   cin.ignore();
    vector<string> rem_cand;
-   for (int i = 0; i < n; ++i)
+   string cand;
+   while (true)
    {
-      string cand;
-      getline(cin, cand);
+      if (!getline(cin, cand))
+         break;
+      if (cand.empty())
+         break;
       rem_cand.push_back(cand);
    }
    if (UDT::ERROR == UDT::setICEInfo(client, rem_ufrag, rem_pwd, rem_cand))

--- a/app/appniceserver.cpp
+++ b/app/appniceserver.cpp
@@ -52,20 +52,18 @@ int main(int argc, char* argv[])
    for (vector<string>::iterator it = candidates.begin(); it != candidates.end(); ++it)
       cout << *it << endl;
 
+   cout << "Paste remote ICE info (username fragment, password, candidates) and end with an empty line:" << endl;
    string rem_ufrag, rem_pwd;
-   cout << "Enter remote ICE username fragment: ";
    getline(cin, rem_ufrag);
-   cout << "Enter remote ICE password: ";
    getline(cin, rem_pwd);
-   cout << "Enter number of remote candidates: ";
-   int n = 0;
-   cin >> n;
-   cin.ignore();
    vector<string> rem_cand;
-   for (int i = 0; i < n; ++i)
+   string cand;
+   while (true)
    {
-      string cand;
-      getline(cin, cand);
+      if (!getline(cin, cand))
+         break;
+      if (cand.empty())
+         break;
       rem_cand.push_back(cand);
    }
    if (UDT::ERROR == UDT::setICEInfo(serv, rem_ufrag, rem_pwd, rem_cand))


### PR DESCRIPTION
## Summary
- Replace step-by-step remote ICE entry with single multi-line paste in NICE server and client apps.
- Read remote username fragment, password, and any number of candidates using getline until a blank line is encountered.

## Testing
- `make -C src`
- `make -C app`


------
https://chatgpt.com/codex/tasks/task_e_68c10ee73864832ca795dc7d25b1e092