### PR TITLE
Close channel only after queue threads exit

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -235,10 +235,10 @@ int CUDTUnited::cleanup()
    // threads that depend on them are destroyed.
    for (map<int, CMultiplexer>::iterator i = m_mMultiplexer.begin(); i != m_mMultiplexer.end(); ++ i)
    {
-      if (i->second.m_pChannel)
-         i->second.m_pChannel->close();
       delete i->second.m_pSndQueue;
       delete i->second.m_pRcvQueue;
+      if (i->second.m_pChannel)
+         i->second.m_pChannel->close();
       delete i->second.m_pTimer;
       delete i->second.m_pChannel;
    }
@@ -1347,20 +1347,17 @@ void CUDTUnited::removeSocket(const UDTSOCKET u)
    // delete this one
    i->second->m_pUDT->close();
 
-   // If this is the last socket using the multiplexer, close the channel
-   // before any worker threads in the queues are terminated by the
-   // destructors below.
-   if (m->second.m_iRefCount == 1)
-      m->second.m_pChannel->close();
+   const bool last = (m->second.m_iRefCount == 1);
 
    delete i->second;
    m_ClosedSockets.erase(i);
 
    m->second.m_iRefCount --;
-   if (0 == m->second.m_iRefCount)
+   if (last)
    {
       delete m->second.m_pSndQueue;
       delete m->second.m_pRcvQueue;
+      m->second.m_pChannel->close();
       delete m->second.m_pTimer;
       delete m->second.m_pChannel;
       m_mMultiplexer.erase(m);

--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -131,6 +131,9 @@ void CNiceChannel::close()
    if (m_pLoop)
       g_main_loop_quit(m_pLoop);
 
+   if (m_pRecvQueue)
+      g_async_queue_push(m_pRecvQueue, NULL);
+
    if (m_pThread)
    {
       g_thread_join(m_pThread);


### PR DESCRIPTION
## Summary
- destroy send/receive queues before closing their channels
- push sentinel to wake CNiceChannel recv queue and unref after thread exit

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c1771cbda0832caa4cef324d5c9f7c