### PR TITLE
Add receive diagnostics to appniceserver

### DIFF
--- a/app/appniceserver.cpp
+++ b/app/appniceserver.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <cctype>
 #include <cstdint>
+#include <algorithm>
 #include <udt.h>
 #include "test_util.h"
 
@@ -241,9 +242,24 @@ DWORD WINAPI recvdata(LPVOID usocket)
          }
 
          rsize += rs;
-      }
+         total += rs;
 
-      total += rsize;
+         const int preview_len = min(rs, 32);
+         string preview;
+         preview.reserve(preview_len);
+         for (int i = 0; i < preview_len; ++i)
+         {
+            unsigned char ch = static_cast<unsigned char>(data[rsize - rs + i]);
+            preview += isprint(ch) ? static_cast<char>(ch) : '.';
+         }
+
+         cout << "Received " << rs << " bytes (iteration total: " << rsize
+              << ", cumulative total: " << total << ")";
+         if (preview_len > 0)
+            cout << ", preview: \"" << preview << "\"";
+         cout << endl;
+         cout.flush();
+      }
 
       if (done || rsize < size)
          break;


### PR DESCRIPTION
## Summary
- track bytes received per UDT::recv call and cumulatively
- log receive diagnostics with a bounded payload preview and explicit flushes for visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb7996aa1c832c9cf9f33bd239dfab