### PR TITLE
Ensure CNiceChannel send/close synchronization

### DIFF
--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -98,11 +98,12 @@ public:
 private:
    struct SendRequest
    {
-      const CNiceChannel* channel;
+      CNiceChannel*       channel;
       guint8*              buffer;
       gsize                size;
       int                  result;
       bool                 completed;
+      bool                 tracked;
       GMutex               mutex;
       GCond                cond;
 
@@ -112,6 +113,7 @@ private:
       , size(0)
       , result(-1)
       , completed(false)
+      , tracked(false)
       {
          g_mutex_init(&mutex);
          g_cond_init(&cond);
@@ -154,6 +156,10 @@ private:
    bool           m_bControlling;
    mutable sockaddr_storage m_SockAddr;
    mutable sockaddr_storage m_PeerAddr;
+   mutable GMutex m_CloseLock;
+   mutable GCond  m_CloseCond;
+   mutable bool   m_bClosing;
+   mutable guint  m_ActiveSends;
 };
 
 #endif // USE_LIBNICE


### PR DESCRIPTION
## Summary
- add a close lock/condition pair plus state tracking to CNiceChannel for coordinating send callbacks with teardown
- guard send dispatch with the new synchronization so that nice_agent_send is skipped once closing begins
- wait for outstanding send operations before dismantling the libnice agent and reset the tracking state on reopen

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cbaa1e0740832c948c8f2a23c9622d