### PR TITLE
Use std::this_thread::sleep_for in appniceclient send loop

### DIFF
--- a/app/appniceclient.cpp
+++ b/app/appniceclient.cpp
@@ -13,6 +13,8 @@
 #include <vector>
 #include <sstream>
 #include <cctype>
+#include <chrono>
+#include <thread>
 #include <udt.h>
 #include "test_util.h"
 
@@ -229,11 +231,7 @@ int main(int argc, char* argv[])
 
       cout << "Sent: " << message << endl;
 
-#ifndef WIN32
-      sleep(1);
-#else
-      Sleep(1000);
-#endif
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
    }
 
    running = false;


### PR DESCRIPTION
## Summary
- include `<chrono>` and `<thread>` so the client can use the standard sleep utilities
- replace the platform-specific sleep macros in the send loop with `std::this_thread::sleep_for` for a uniform 1 ms delay

## Testing
- make -C src
- make -C app appniceclient

------
https://chatgpt.com/codex/tasks/task_e_68cbcb474010832cb72010ed27ff74fa