### PR TITLE
Handle libnice send retries and add regression test

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -49,7 +49,7 @@ endif
 
 DIR = $(shell pwd)
 
-APP = appserver appclient sendfile recvfile test appniceserver appniceclient
+APP = appserver appclient sendfile recvfile test appniceserver appniceclient nice_channel_retry_test
 
 all: $(APP)
 
@@ -69,6 +69,8 @@ test: test.o
 appniceserver: appniceserver.o
 	$(CXX) $^ -o $@ $(LIBS)
 appniceclient: appniceclient.o
+	$(CXX) $^ -o $@ $(LIBS)
+nice_channel_retry_test: nice_channel_retry_test.o
 	$(CXX) $^ -o $@ $(LIBS)
 
 clean:

--- a/app/nice_channel_retry_test.cpp
+++ b/app/nice_channel_retry_test.cpp
@@ -1,0 +1,107 @@
+#ifdef USE_LIBNICE
+
+#define private public
+#include "nice_channel.h"
+#undef private
+#include "packet.h"
+
+#include <glib.h>
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+
+namespace
+{
+int g_send_attempts = 0;
+
+gint FakeNiceAgentSend(NiceAgent*, guint, guint, gsize len, const gchar*)
+{
+   ++ g_send_attempts;
+   if (g_send_attempts == 1)
+   {
+      errno = EAGAIN;
+      return -1;
+   }
+   return static_cast<gint>(len);
+}
+}
+
+int main()
+{
+   g_send_attempts = 0;
+   CNiceChannel::SetAgentSendFuncForTesting(&FakeNiceAgentSend);
+
+   CNiceChannel channel;
+   GMainContext* context = g_main_context_new();
+   g_main_context_push_thread_default(context);
+
+   channel.m_pContext = context;
+   channel.m_pAgent = reinterpret_cast<NiceAgent*>(0x1);
+   channel.m_iStreamID = 1;
+   channel.m_iComponentID = 1;
+
+   CPacket packet;
+   packet.setLength(8);
+   for (int i = 0; i < packet.getLength(); ++ i)
+      packet.m_pcData[i] = static_cast<char>(i);
+
+   const int result = channel.sendto(NULL, packet);
+
+   g_main_context_pop_thread_default(context);
+
+   const int expected_size = CPacket::m_iPktHdrSize + packet.getLength();
+   if (result != expected_size)
+   {
+      std::cerr << "Unexpected send result: " << result << " expected " << expected_size << std::endl;
+      CNiceChannel::SetAgentSendFuncForTesting(NULL);
+      g_main_context_unref(context);
+      channel.m_pContext = NULL;
+      channel.m_pAgent = NULL;
+      return 1;
+   }
+
+   if (g_send_attempts != 2)
+   {
+      std::cerr << "Retry count mismatch: " << g_send_attempts << std::endl;
+      CNiceChannel::SetAgentSendFuncForTesting(NULL);
+      g_main_context_unref(context);
+      channel.m_pContext = NULL;
+      channel.m_pAgent = NULL;
+      return 1;
+   }
+
+   if (channel.m_ActiveSends != 0)
+   {
+      std::cerr << "Active send count not cleared." << std::endl;
+      CNiceChannel::SetAgentSendFuncForTesting(NULL);
+      g_main_context_unref(context);
+      channel.m_pContext = NULL;
+      channel.m_pAgent = NULL;
+      return 1;
+   }
+
+   if (channel.m_bFailed)
+   {
+      std::cerr << "Channel erroneously marked as failed." << std::endl;
+      CNiceChannel::SetAgentSendFuncForTesting(NULL);
+      g_main_context_unref(context);
+      channel.m_pContext = NULL;
+      channel.m_pAgent = NULL;
+      return 1;
+   }
+
+   CNiceChannel::SetAgentSendFuncForTesting(NULL);
+
+   g_main_context_unref(context);
+   channel.m_pContext = NULL;
+   channel.m_pAgent = NULL;
+
+   return 0;
+}
+
+#else
+int main()
+{
+   return 0;
+}
+#endif


### PR DESCRIPTION
## Summary
- keep CNiceChannel::SendRequest instances alive across retries using ref counting and defer buffer cleanup until completion
- teach cb_send_dispatch to resubmit on EAGAIN/EWOULDBLOCK, set a fatal failure flag otherwise, and expose a testing hook for nice_agent_send
- add a regression test that stubs nice_agent_send to deliver EAGAIN once and verifies the request is retried successfully

## Testing
- make -C app nice_channel_retry_test
- ./app/nice_channel_retry_test

------
https://chatgpt.com/codex/tasks/task_e_68cbd5ba65f8832c953dc486e222e00b