### PR TITLE
Fix NiceAgentSend hook signature for Windows compatibility

### DIFF
--- a/app/nice_channel_retry_test.cpp
+++ b/app/nice_channel_retry_test.cpp
@@ -14,7 +14,7 @@ namespace
 {
 int g_send_attempts = 0;
 
-gint FakeNiceAgentSend(NiceAgent*, guint, guint, gsize len, const gchar*)
+gint FakeNiceAgentSend(NiceAgent*, guint, guint, guint len, const gchar*)
 {
    ++ g_send_attempts;
    if (g_send_attempts == 1)

--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -301,7 +301,9 @@ int CNiceChannel::sendto(const sockaddr* addr, CPacket& packet) const
    }
 
    const int size = CPacket::m_iPktHdrSize + packet.getLength();
-   guint8* buf = (guint8*)g_malloc(size);
+   const gsize alloc_size = static_cast<gsize>(size);
+   const guint send_size = static_cast<guint>(size);
+   guint8* buf = static_cast<guint8*>(g_malloc(alloc_size));
    memcpy(buf, packet.header(), CPacket::m_iPktHdrSize);
    memcpy(buf + CPacket::m_iPktHdrSize, packet.m_pcData, packet.getLength());
 
@@ -331,7 +333,7 @@ int CNiceChannel::sendto(const sockaddr* addr, CPacket& packet) const
          SendRequest* request = new SendRequest();
          request->channel = self;
          request->buffer = buf;
-         request->size = size;
+         request->size = send_size;
          request->completed = false;
          request->tracked = true;
          request->pending = true;

--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -100,7 +100,7 @@ private:
    {
       CNiceChannel*       channel;
       guint8*              buffer;
-      gsize                size;
+      guint                size;
       int                  result;
       bool                 completed;
       bool                 tracked;
@@ -157,7 +157,7 @@ private:
    static gboolean cb_send_dispatch(gpointer data);
    static void destroy_send_request(gpointer data);
 
-   typedef gint (*NiceAgentSendFunc)(NiceAgent*, guint, guint, gsize, const gchar*);
+   typedef gint (*NiceAgentSendFunc)(NiceAgent*, guint, guint, guint, const gchar*);
 
 public:
    static void SetAgentSendFuncForTesting(NiceAgentSendFunc func);


### PR DESCRIPTION
## Summary
- align `CNiceChannel::NiceAgentSendFunc` with the Windows `nice_agent_send` signature by switching the length parameter to `guint`
- update send request handling to store the guint payload size while keeping allocation sizes as `gsize`
- adjust the retry test hook to match the new signature

## Testing
- make -C src libudt.a
- make -C app appniceserver nice_channel_retry_test
- ./app/nice_channel_retry_test


------
https://chatgpt.com/codex/tasks/task_e_68cbdb5f4e14832c93d49a8b507697ef