### PR TITLE
Configure GStreamer sample builds

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -6,17 +6,30 @@ set(APP_SOURCES
     test.cpp
     appniceserver.cpp
     appniceclient.cpp
+    appgstclient.cpp
+    appgstserver.cpp
 )
 
 option(UDT_COPY_DLL "Copy udt.dll beside executables for dynamic linking" OFF)
 
 find_package(Threads)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GST REQUIRED IMPORTED_TARGET gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0)
+
+set(GST_APP_TARGETS
+  appgstclient
+  appgstserver
+)
 
 foreach(src ${APP_SOURCES})
   get_filename_component(exe ${src} NAME_WE)
   add_executable(${exe} ${src})
+  list(FIND GST_APP_TARGETS ${exe} _is_gst_target)
   if(WIN32)
     target_link_libraries(${exe} PRIVATE udt_static Threads::Threads m ws2_32)
+    if(_is_gst_target GREATER -1)
+      target_link_libraries(${exe} PRIVATE PkgConfig::GST)
+    endif()
     target_compile_definitions(${exe} PRIVATE UDT_EXPORTS)
     if(UDT_COPY_DLL)
       add_custom_command(TARGET ${exe} POST_BUILD
@@ -26,6 +39,13 @@ foreach(src ${APP_SOURCES})
     endif()
   else()
     target_link_libraries(${exe} PRIVATE udt Threads::Threads m)
+    if(_is_gst_target GREATER -1)
+      target_link_libraries(${exe} PRIVATE PkgConfig::GST)
+    endif()
+  endif()
+  if(_is_gst_target GREATER -1)
+    target_compile_options(${exe} PRIVATE ${GST_CFLAGS_OTHER})
+    target_include_directories(${exe} PRIVATE ${GST_INCLUDE_DIRS})
   endif()
   target_compile_options(${exe} PRIVATE -Wall -finline-functions -O3)
   target_include_directories(${exe} PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/app/Makefile
+++ b/app/Makefile
@@ -16,10 +16,14 @@ ifneq ($(findstring glib-2.0,$(NICE_CFLAGS)),glib-2.0)
 NICE_CFLAGS := $(shell $(PKG_CONFIG) --cflags nice glib-2.0 2>/dev/null)
 endif
 NICE_LIBS ?= $(shell $(PKG_CONFIG) --libs nice 2>/dev/null)
+GST_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 2>/dev/null)
+GST_LIBS ?= $(shell $(PKG_CONFIG) --libs gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 2>/dev/null)
 CXXFLAGS += $(NICE_CFLAGS)
 # For systems without pkg-config, set NICE_CFLAGS and NICE_LIBS manually, e.g.:
 # NICE_CFLAGS=-I/usr/include/nice -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
 # NICE_LIBS=-lnice -lglib-2.0
+# GST_CFLAGS=-I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
+# GST_LIBS=-lgstreamer-1.0 -lgstapp-1.0 -lgstvideo-1.0
 
 ifeq ($(arch), IA32)
    CXXFLAGS += -DIA32 #-mcpu=pentiumpro -march=pentiumpro -mmmx -msse
@@ -49,7 +53,10 @@ endif
 
 DIR = $(shell pwd)
 
-APP = appserver appclient sendfile recvfile test appniceserver appniceclient nice_channel_retry_test
+APP = appserver appclient sendfile recvfile test appniceserver appniceclient appgstserver appgstclient nice_channel_retry_test
+
+appgstserver.o: CXXFLAGS += $(GST_CFLAGS)
+appgstclient.o: CXXFLAGS += $(GST_CFLAGS)
 
 all: $(APP)
 
@@ -70,6 +77,10 @@ appniceserver: appniceserver.o
 	$(CXX) $^ -o $@ $(LIBS)
 appniceclient: appniceclient.o
 	$(CXX) $^ -o $@ $(LIBS)
+appgstserver: appgstserver.o
+	$(CXX) $^ -o $@ $(LIBS) $(GST_LIBS)
+appgstclient: appgstclient.o
+	$(CXX) $^ -o $@ $(LIBS) $(GST_LIBS)
 nice_channel_retry_test: nice_channel_retry_test.o
 	$(CXX) $^ -o $@ $(LIBS)
 


### PR DESCRIPTION
## Summary
- add the new GStreamer sample sources to the app CMake build, pull their dependencies with pkg-config, and link them on every platform
- extend the GNU Make build to understand the GStreamer targets with dedicated compile and link flags

## Testing
- cmake -S . -B build *(fails: missing gstreamer-1.0/gstreamer-app-1.0/gstreamer-video-1.0 packages in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc08041bd8832c9397baca50eb0369