### PR TITLE
Adjust GStreamer property helpers to avoid gboolean overload

### DIFF
--- a/app/appgstclient.cpp
+++ b/app/appgstclient.cpp
@@ -203,11 +203,11 @@ void set_property_if_exists(GstElement* element, const char* property, gint valu
       g_object_set(element, property, value, nullptr);
 }
 
-void set_property_if_exists(GstElement* element, const char* property, gboolean value)
+void set_property_if_exists(GstElement* element, const char* property, bool value)
 {
    GParamSpec* pspec = g_object_class_find_property(G_OBJECT_GET_CLASS(element), property);
    if (pspec && (G_PARAM_SPEC_VALUE_TYPE(pspec) == G_TYPE_BOOLEAN))
-      g_object_set(element, property, value, nullptr);
+      g_object_set(element, property, value ? TRUE : FALSE, nullptr);
 }
 
 void set_property_if_exists(GstElement* element, const char* property, const char* value)
@@ -420,13 +420,13 @@ bool run_pipeline(PipelineContext& ctx)
 
    g_object_set(queue, "leaky", 2, "max-size-buffers", 2, "max-size-time", static_cast<guint64>(0), nullptr);
 
-   set_property_if_exists(source, "cursor", TRUE);
-   set_property_if_exists(source, "show-cursor", TRUE);
-   set_property_if_exists(source, "is-live", TRUE);
+   set_property_if_exists(source, "cursor", true);
+   set_property_if_exists(source, "show-cursor", true);
+   set_property_if_exists(source, "is-live", true);
 
    set_property_if_exists(encoder, "tune", "zerolatency");
    set_property_if_exists(encoder, "speed-preset", "ultrafast");
-   set_property_if_exists(encoder, "low-latency", TRUE);
+   set_property_if_exists(encoder, "low-latency", true);
    set_property_if_exists(encoder, "bframes", 0);
 
    g_object_set(parse, "config-interval", 1, nullptr);

--- a/app/appgstserver.cpp
+++ b/app/appgstserver.cpp
@@ -164,11 +164,11 @@ std::string choose_video_sink()
    return std::string();
 }
 
-void set_property_if_exists(GstElement* element, const char* property, gboolean value)
+void set_property_if_exists(GstElement* element, const char* property, bool value)
 {
    GParamSpec* pspec = g_object_class_find_property(G_OBJECT_GET_CLASS(element), property);
    if (pspec && (G_PARAM_SPEC_VALUE_TYPE(pspec) == G_TYPE_BOOLEAN))
-      g_object_set(element, property, value, nullptr);
+      g_object_set(element, property, value ? TRUE : FALSE, nullptr);
 }
 
 void set_property_if_exists(GstElement* element, const char* property, gint value)
@@ -287,10 +287,10 @@ bool setup_pipeline(ServerPipelineContext& ctx, GstCaps* caps, const std::string
 
    set_property_if_exists(parse, "config-interval", 1);
 
-   set_property_if_exists(sink, "sync", FALSE);
-   set_property_if_exists(sink, "enable-last-sample", FALSE);
-   set_property_if_exists(sink, "async", FALSE);
-   set_property_if_exists(sink, "qos", FALSE);
+   set_property_if_exists(sink, "sync", false);
+   set_property_if_exists(sink, "enable-last-sample", false);
+   set_property_if_exists(sink, "async", false);
+   set_property_if_exists(sink, "qos", false);
    set_property_if_exists(sink, "max-lateness", static_cast<gint64>(0));
 
    gst_bin_add_many(GST_BIN(pipeline), appsrc, queue, parse, decodebin, sink_queue, sink, nullptr);


### PR DESCRIPTION
## Summary
- update the GStreamer property helper overloads to take a distinct `bool` parameter when setting boolean values
- switch the app client and server call sites to use the new helper signature

## Testing
- cmake -S . -B build *(fails: missing gstreamer-1.0, gstreamer-app-1.0, gstreamer-video-1.0 packages in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1097d4c4832c802ddf17574ca943