### PR TITLE
Fix chrono usage in appgstclient

### DIFF
--- a/app/appgstclient.cpp
+++ b/app/appgstclient.cpp
@@ -27,8 +27,6 @@
 
 #include "test_util.h"
 
-using namespace std::chrono_literals;
-
 namespace
 {
 std::string encodeField(const std::string& value)
@@ -117,7 +115,7 @@ bool send_all_nonblocking(UDTSOCKET sock, const guint8* data, size_t len, std::a
          CUDTException ex = UDT::getlasterror();
          if (CUDTException::EASYNCSND == ex.getErrorCode())
          {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
             continue;
          }
          std::cerr << "send: " << ex.getErrorMessage() << std::endl;


### PR DESCRIPTION
## Summary
- remove use of std::chrono_literals in appgstclient to avoid namespace pollution
- replace the 1ms literal with an explicit std::chrono::milliseconds duration for the sleep call

## Testing
- cmake -S app -B build-win -G Ninja -DCMAKE_SYSTEM_NAME=Windows *(fails: Linux linker does not support Windows options in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc15b22a98832c92469c7399adf048