### PR TITLE
Handle transient ENOBUFS errors in libnice send

### DIFF
--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -493,8 +493,9 @@ gboolean CNiceChannel::cb_send_dispatch(gpointer data)
          else
          {
             int err = errno;
-            if ((EAGAIN == err || EWOULDBLOCK == err) && context)
+            if ((EAGAIN == err || EWOULDBLOCK == err || ENOBUFS == err || ENOMEM == err || EINTR == err) && context)
             {
+               // Temporary congestion signals from the kernel; retry the send later.
                reschedule = true;
             }
             else


### PR DESCRIPTION
## Summary
- allow transient kernel send-buffer errors (ENOBUFS/ENOMEM/EINTR) to trigger the existing send reschedule path
- document that these errno values indicate temporary congestion so the channel can retry without marking the connection failed

## Testing
- make -C src all
- make -C app nice_channel_retry_test
- ./app/nice_channel_retry_test

------
https://chatgpt.com/codex/tasks/task_e_68cd2a046460832c862d7b7eef0ca7ea