### PR TITLE
Enable libnice and UDT debug logging

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,5 +59,18 @@ Read index.htm in ./doc. The documentation is in HTML format and requires your
 browser to support JavaScript.
 
 
+Debug logging
+-------------
+Set the `LIBNICE_DEBUG` environment variable to a non-empty value (for example,
+`export LIBNICE_DEBUG=1`) before starting an application to enable detailed
+libnice integration logs. The library also honors the fallback variables
+`POLEIS_LIBNICE_DEBUG` and `POLEIS_DEBUG` for the same purpose.
+
+To surface additional diagnostics from the UDT stack, set `UDT_DEBUG` (or the
+fallback variables `POLEIS_UDT_DEBUG` and `POLEIS_DEBUG`) to any value other
+than `0`, `false`, `off`, or `no`. When enabled, the library writes verbose
+status updates and error reports to standard error with a `[UDT]` prefix.
+
+
 Questions? please post to the UDT project forum:
 https://sourceforge.net/projects/udt/forums

--- a/src/api.h
+++ b/src/api.h
@@ -43,6 +43,7 @@ written by
 
 
 #include <map>
+#include <string>
 #include <vector>
 #include "udt.h"
 #include "packet.h"
@@ -294,6 +295,12 @@ private:
 private:
    CUDTUnited(const CUDTUnited&);
    CUDTUnited& operator=(const CUDTUnited&);
+
+private:
+   void ensureDebugLoggingInitialized();
+   void logDebug(const char* fmt, ...) const;
+   bool m_bDebugLoggingEnabled;
+   bool m_bDebugLoggingInitialized;
 };
 
 #endif

--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -188,6 +188,11 @@ private:
    mutable guint  m_ActiveSends;
 
    static NiceAgentSendFunc s_SendFunc;
+   static gsize s_DebugInitToken;
+   static gboolean s_DebugLoggingEnabled;
+   static void EnsureDebugLoggingInitialized();
+   static gboolean IsDebugLoggingEnabled();
+   static void DebugLog(const gchar* format, ...) G_GNUC_PRINTF(1, 2);
 };
 
 #endif // USE_LIBNICE


### PR DESCRIPTION
## Summary
- document the environment variables required to enable libnice and UDT debug output
- add environment-controlled debug logging to the libnice channel implementation
- introduce UDT-level debug logging that traces lifecycle events and captured errors

## Testing
- make -C src

------
https://chatgpt.com/codex/tasks/task_e_68cd7e9c4078832ca55f2d72d3b00145