### PR TITLE
Prevent CNiceChannel recvfrom from blocking indefinitely

### DIFF
--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -534,9 +534,15 @@ int CNiceChannel::recvfrom(sockaddr* addr, CPacket& packet) const
          memcpy(addr, &m_PeerAddr, sizeof(sockaddr_in6));
    }
 
-   GByteArray* arr = (GByteArray*)g_async_queue_pop(m_pRecvQueue);
+   const guint64 timeout_usec = G_USEC_PER_SEC / 100;
+   GByteArray* arr = NULL;
+   if (m_pRecvQueue)
+      arr = static_cast<GByteArray*>(g_async_queue_timeout_pop(m_pRecvQueue, timeout_usec));
    if (NULL == arr)
+   {
+      packet.setLength(-1);
       return -1;
+   }
 
    int size = arr->len;
    if (size < CPacket::m_iPktHdrSize)


### PR DESCRIPTION
## Summary
- use g_async_queue_timeout_pop in CNiceChannel::recvfrom to align with the legacy UDP poll cadence
- return no data when the receive queue times out or yields a NULL sentinel so close() can still wake the worker

## Testing
- make -C src

------
https://chatgpt.com/codex/tasks/task_e_68cebc00c264832ca11baf89d0d594cc