### PR TITLE
Set recv timeout to non-fatal error

### DIFF
--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -540,6 +540,11 @@ int CNiceChannel::recvfrom(sockaddr* addr, CPacket& packet) const
       arr = static_cast<GByteArray*>(g_async_queue_timeout_pop(m_pRecvQueue, timeout_usec));
    if (NULL == arr)
    {
+#ifdef WIN32
+      WSASetLastError(WSAEWOULDBLOCK);
+#else
+      errno = EAGAIN;
+#endif
       packet.setLength(-1);
       return -1;
    }


### PR DESCRIPTION
## Summary
- set errno/WSA error when libnice recv queue pop times out to mirror UDP behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cec1375ea0832c889d428e05207de8