### PR TITLE
Ensure NICE include dirs propagate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ endforeach()
 
 if(NICE_FOUND)
   foreach(tgt udt udt_static)
-    target_include_directories(${tgt} PRIVATE ${NICE_INCLUDE_DIRS})
+    target_include_directories(${tgt} PUBLIC ${NICE_INCLUDE_DIRS})
     target_link_libraries(${tgt} PUBLIC ${NICE_LIBRARIES})
     target_compile_options(${tgt} PRIVATE ${NICE_CFLAGS_OTHER})
     target_compile_definitions(${tgt} PUBLIC USE_LIBNICE)


### PR DESCRIPTION
## Summary
- expose the libnice include directories from the udt libraries so downstream targets inherit GLib headers

## Testing
- cmake -S . -B build *(fails: missing gstreamer-1.0, gstreamer-app-1.0, and gstreamer-video-1.0 packages in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf67809a48832ca39a3d79e772f3be