### PR TITLE
Export CNiceChannel symbols under hidden visibility

### DIFF
--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -52,7 +52,7 @@ written by
 #include <string>
 #include <vector>
 
-class CNiceChannel
+class UDT_API CNiceChannel
 {
 public:
    CNiceChannel(bool controlling = false);


### PR DESCRIPTION
## Summary
- add the UDT_API export annotation to the CNiceChannel class so its members remain visible when building with hidden defaults

## Testing
- cmake .. *(fails: missing gstreamer pkg-config modules in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf695390b4832c950b9f1a282409d0