### PR TITLE
Export CPacket when building with hidden visibility

### DIFF
--- a/src/packet.h
+++ b/src/packet.h
@@ -59,7 +59,7 @@ typedef CNiceChannel CChannel;
 class CChannel;
 #endif
 
-class CPacket
+class UDT_API CPacket
 {
 #ifdef USE_LIBNICE
 friend CChannel;


### PR DESCRIPTION
## Summary
- mark the CPacket class declaration with the UDT_API visibility macro so the packet implementation stays exported when hidden visibility is enabled

## Testing
- make -C src
- make -C app nice_channel_retry_test

------
https://chatgpt.com/codex/tasks/task_e_68cf6be4fdc8832c861d9f3f0d92f14c