### PR TITLE
Fix error handling around sendAll failures in appnicefileclient

### DIFF
--- a/app/appnicefileclient.cpp
+++ b/app/appnicefileclient.cpp
@@ -281,30 +281,20 @@ int main(int argc, char *argv[])
    if (!sendAll(client, reinterpret_cast<const char *>(&name_len), sizeof(name_len)))
    {
       stop_monitor();
-
-   const int32_t name_len = static_cast<int32_t>(filename.size());
-   if (!sendAll(client, reinterpret_cast<const char *>(&name_len), sizeof(name_len)))
-   {
-
       UDT::close(client);
       return 1;
    }
 
    if (!sendAll(client, filename.data(), name_len))
    {
-
       stop_monitor();
-
-
       UDT::close(client);
       return 1;
    }
 
    if (!sendAll(client, reinterpret_cast<const char *>(&filesize), sizeof(filesize)))
    {
-
       stop_monitor();
-
       UDT::close(client);
       return 1;
    }


### PR DESCRIPTION
## Summary
- ensure the initial name length send failure properly stops the monitor and returns before continuing
- remove the duplicated name length declaration so each send failure check closes cleanly

## Testing
- make -C src
- make -C app appnicefileclient

------
https://chatgpt.com/codex/tasks/task_e_68cf9f8f123c832c815a9a5c21d2ccd1