### PR TITLE
Add STUN/TURN configuration APIs for libnice transport

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -52,7 +52,12 @@ connectivity checks, supply the remote values with `UDT::setICEInfo()`. The
 sample `appniceclient` and `appniceserver` programs output these fields on a
 single line by concatenating length-prefixed strings (for example,
 `4:abcd10:passphrase...`). Copy the full line and provide the remote peer's line
-when prompted.
+when prompted. Applications may configure optional STUN and TURN services via
+`UDT::setICESTUNServer()` and `UDT::setICETURNServer()` prior to requesting ICE
+information. Passing an empty server string disables the associated relay.
+The `appnice*` and `appgst*` samples expose these hooks through the
+`--stun=HOST[:PORT]` and `--turn=HOST[:PORT],USERNAME,PASSWORD` command-line
+options so you can test against public STUN/TURN infrastructure if desired.
 
 To use UDT in your application:
 Read index.htm in ./doc. The documentation is in HTML format and requires your

--- a/app/appgstserver.cpp
+++ b/app/appgstserver.cpp
@@ -512,10 +512,31 @@ void handle_connection(UDTSOCKET sock)
 
 int main(int argc, char* argv[])
 {
-   const char* usage = "usage: appgstserver [--verbose|--quiet]";
+   const char* usage =
+      "usage: appgstserver [--verbose|--quiet]"
+#ifdef USE_LIBNICE
+      " [--stun=HOST[:PORT]] [--turn=HOST[:PORT],USERNAME,PASSWORD]"
+#endif
+      "";
+#ifdef USE_LIBNICE
+   std::string stun_option;
+   std::string turn_option;
+#endif
    for (int i = 1; i < argc; ++i)
    {
       std::string arg(argv[i]);
+#ifdef USE_LIBNICE
+      if (arg.rfind("--stun=", 0) == 0)
+      {
+         stun_option = arg.substr(7);
+         continue;
+      }
+      if (arg.rfind("--turn=", 0) == 0)
+      {
+         turn_option = arg.substr(7);
+         continue;
+      }
+#endif
       if ((arg == "--verbose") || (arg == "-v") || (arg == "--quiet") || (arg == "-q"))
       {
          // Legacy options retained
@@ -549,6 +570,40 @@ int main(int argc, char* argv[])
    }
 
 #ifdef USE_LIBNICE
+   if (!stun_option.empty())
+   {
+      std::string host;
+      int port = 3478;
+      if (!ParseHostPortSpec(stun_option, host, port))
+      {
+         std::cout << "Invalid STUN server specification: " << stun_option << std::endl;
+         return 0;
+      }
+      if (UDT::ERROR == UDT::setICESTUNServer(serv, host, port))
+      {
+         std::cout << "setICESTUNServer: " << UDT::getlasterror().getErrorMessage() << std::endl;
+         return 0;
+      }
+   }
+
+   if (!turn_option.empty())
+   {
+      std::string server;
+      int port = 3478;
+      std::string username;
+      std::string password;
+      if (!ParseTurnSpec(turn_option, server, port, username, password))
+      {
+         std::cout << "Invalid TURN relay specification: " << turn_option << std::endl;
+         return 0;
+      }
+      if (UDT::ERROR == UDT::setICETURNServer(serv, server, port, username, password))
+      {
+         std::cout << "setICETURNServer: " << UDT::getlasterror().getErrorMessage() << std::endl;
+         return 0;
+      }
+   }
+
    std::string ufrag, pwd;
    std::vector<std::string> candidates;
    if (UDT::ERROR == UDT::getICEInfo(serv, ufrag, pwd, candidates))

--- a/app/appniceclient.cpp
+++ b/app/appniceclient.cpp
@@ -128,10 +128,31 @@ std::string getTimestampUs() {
 
 int main(int argc, char* argv[])
 {
-   const char* usage = "usage: appniceclient [--verbose|--quiet]";
+   const char* usage =
+      "usage: appniceclient [--verbose|--quiet]"
+#ifdef USE_LIBNICE
+      " [--stun=HOST[:PORT]] [--turn=HOST[:PORT],USERNAME,PASSWORD]"
+#endif
+      "";
+#ifdef USE_LIBNICE
+   std::string stun_option;
+   std::string turn_option;
+#endif
    for (int i = 1; i < argc; ++i)
    {
       string arg(argv[i]);
+#ifdef USE_LIBNICE
+      if (arg.rfind("--stun=", 0) == 0)
+      {
+         stun_option = arg.substr(7);
+         continue;
+      }
+      if (arg.rfind("--turn=", 0) == 0)
+      {
+         turn_option = arg.substr(7);
+         continue;
+      }
+#endif
       if ((arg == "--verbose") || (arg == "-v") || (arg == "--quiet") || (arg == "-q"))
       {
          // Legacy options retained for compatibility but no longer change behavior.
@@ -175,6 +196,40 @@ int main(int argc, char* argv[])
    }
 
 #ifdef USE_LIBNICE
+   if (!stun_option.empty())
+   {
+      std::string host;
+      int port = 3478;
+      if (!ParseHostPortSpec(stun_option, host, port))
+      {
+         cout << "Invalid STUN server specification: " << stun_option << endl;
+         return 0;
+      }
+      if (UDT::ERROR == UDT::setICESTUNServer(client, host, port))
+      {
+         cout << "setICESTUNServer: " << UDT::getlasterror().getErrorMessage() << endl;
+         return 0;
+      }
+   }
+
+   if (!turn_option.empty())
+   {
+      std::string server;
+      int port = 3478;
+      std::string username;
+      std::string password;
+      if (!ParseTurnSpec(turn_option, server, port, username, password))
+      {
+         cout << "Invalid TURN relay specification: " << turn_option << endl;
+         return 0;
+      }
+      if (UDT::ERROR == UDT::setICETURNServer(client, server, port, username, password))
+      {
+         cout << "setICETURNServer: " << UDT::getlasterror().getErrorMessage() << endl;
+         return 0;
+      }
+   }
+
    string ufrag, pwd;
    vector<string> candidates;
    if (UDT::ERROR == UDT::getICEInfo(client, ufrag, pwd, candidates))

--- a/app/appniceserver.cpp
+++ b/app/appniceserver.cpp
@@ -95,10 +95,31 @@ bool parseICEInfo(const string &line, string &ufrag, string &pwd, vector<string>
 
 int main(int argc, char* argv[])
 {
-   const char* usage = "usage: appniceserver [--verbose|--quiet]";
+   const char* usage =
+      "usage: appniceserver [--verbose|--quiet]"
+#ifdef USE_LIBNICE
+      " [--stun=HOST[:PORT]] [--turn=HOST[:PORT],USERNAME,PASSWORD]"
+#endif
+      "";
+#ifdef USE_LIBNICE
+   std::string stun_option;
+   std::string turn_option;
+#endif
    for (int i = 1; i < argc; ++i)
    {
       string arg(argv[i]);
+#ifdef USE_LIBNICE
+      if (arg.rfind("--stun=", 0) == 0)
+      {
+         stun_option = arg.substr(7);
+         continue;
+      }
+      if (arg.rfind("--turn=", 0) == 0)
+      {
+         turn_option = arg.substr(7);
+         continue;
+      }
+#endif
       if ((arg == "--verbose") || (arg == "-v") || (arg == "--quiet") || (arg == "-q"))
       {
          // Legacy options retained for compatibility but no longer change behavior.
@@ -130,6 +151,40 @@ int main(int argc, char* argv[])
    }
 
 #ifdef USE_LIBNICE
+   if (!stun_option.empty())
+   {
+      std::string host;
+      int port = 3478;
+      if (!ParseHostPortSpec(stun_option, host, port))
+      {
+         cout << "Invalid STUN server specification: " << stun_option << endl;
+         return 0;
+      }
+      if (UDT::ERROR == UDT::setICESTUNServer(serv, host, port))
+      {
+         cout << "setICESTUNServer: " << UDT::getlasterror().getErrorMessage() << endl;
+         return 0;
+      }
+   }
+
+   if (!turn_option.empty())
+   {
+      std::string server;
+      int port = 3478;
+      std::string username;
+      std::string password;
+      if (!ParseTurnSpec(turn_option, server, port, username, password))
+      {
+         cout << "Invalid TURN relay specification: " << turn_option << endl;
+         return 0;
+      }
+      if (UDT::ERROR == UDT::setICETURNServer(serv, server, port, username, password))
+      {
+         cout << "setICETURNServer: " << UDT::getlasterror().getErrorMessage() << endl;
+         return 0;
+      }
+   }
+
    string ufrag, pwd;
    vector<string> candidates;
    if (UDT::ERROR == UDT::getICEInfo(serv, ufrag, pwd, candidates))

--- a/app/test_util.h
+++ b/app/test_util.h
@@ -14,4 +14,78 @@ struct UDTUpDown{
    }
 };
 
+#ifdef USE_LIBNICE
+#include <string>
+#include <cstdlib>
+
+inline bool ParseHostPortSpec(const std::string& spec, std::string& host, int& port, int default_port = 3478)
+{
+   if (spec.empty())
+      return false;
+
+   std::string host_part;
+   std::string port_part;
+   if (spec[0] == '[')
+   {
+      std::string::size_type end = spec.find(']');
+      if (end == std::string::npos)
+         return false;
+      host_part = spec.substr(1, end - 1);
+      if (end + 1 < spec.size())
+      {
+         if (spec[end + 1] != ':')
+            return false;
+         port_part = spec.substr(end + 2);
+      }
+   }
+   else
+   {
+      std::string::size_type colon = spec.rfind(':');
+      if (colon != std::string::npos && spec.find(':') == colon)
+      {
+         host_part = spec.substr(0, colon);
+         port_part = spec.substr(colon + 1);
+      }
+      else
+      {
+         host_part = spec;
+      }
+   }
+
+   if (host_part.empty())
+      return false;
+
+   port = default_port;
+   if (!port_part.empty())
+   {
+      char* end = NULL;
+      long value = strtol(port_part.c_str(), &end, 10);
+      if ((NULL == end) || (*end != '\0') || (value <= 0) || (value > 65535))
+         return false;
+      port = static_cast<int>(value);
+   }
+
+   host.swap(host_part);
+   return true;
+}
+
+inline bool ParseTurnSpec(const std::string& spec, std::string& server, int& port,
+                          std::string& username, std::string& password, int default_port = 3478)
+{
+   std::string::size_type first = spec.find(',');
+   if (first == std::string::npos)
+      return false;
+   std::string host_port = spec.substr(0, first);
+   std::string rest = spec.substr(first + 1);
+   std::string::size_type second = rest.find(',');
+   if (second == std::string::npos)
+      return false;
+   username = rest.substr(0, second);
+   password = rest.substr(second + 1);
+   if (!ParseHostPortSpec(host_port, server, port, default_port))
+      return false;
+   return true;
+}
+#endif
+
 #endif

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -121,6 +121,13 @@ CUDT::CUDT()
    m_pCC = NULL;
    m_pCache = NULL;
 
+#ifdef USE_LIBNICE
+   m_bHasStunServer = false;
+   m_iStunPort = 0;
+   m_bHasTurnRelay = false;
+   m_iTurnPort = 0;
+#endif
+
    // Initial status
    m_bOpened = false;
    m_bListening = false;
@@ -173,6 +180,17 @@ CUDT::CUDT(const CUDT& ancestor)
    m_pCCFactory = ancestor.m_pCCFactory->clone();
    m_pCC = NULL;
    m_pCache = ancestor.m_pCache;
+
+#ifdef USE_LIBNICE
+   m_bHasStunServer = ancestor.m_bHasStunServer;
+   m_strStunServer = ancestor.m_strStunServer;
+   m_iStunPort = ancestor.m_iStunPort;
+   m_bHasTurnRelay = ancestor.m_bHasTurnRelay;
+   m_strTurnServer = ancestor.m_strTurnServer;
+   m_iTurnPort = ancestor.m_iTurnPort;
+   m_strTurnUsername = ancestor.m_strTurnUsername;
+   m_strTurnPassword = ancestor.m_strTurnPassword;
+#endif
 
    // Initial status
    m_bOpened = false;

--- a/src/core.h
+++ b/src/core.h
@@ -112,6 +112,9 @@ public: //API
                          std::vector<std::string>& candidates);
    static int setICEInfo(UDTSOCKET u, const std::string& ufrag, const std::string& pwd,
                          const std::vector<std::string>& candidates);
+   static int setICESTUNServer(UDTSOCKET u, const std::string& server, int port);
+   static int setICETURNServer(UDTSOCKET u, const std::string& server, int port,
+                               const std::string& username, const std::string& password);
 #endif
 
 public: // internal API
@@ -332,6 +335,16 @@ private: // Status
    CHandShake m_ConnReq;			// connection request
    CHandShake m_ConnRes;			// connection response
    int64_t m_llLastReqTime;			// last time when a connection request is sent
+#ifdef USE_LIBNICE
+   bool m_bHasStunServer;
+   std::string m_strStunServer;
+   int m_iStunPort;
+   bool m_bHasTurnRelay;
+   std::string m_strTurnServer;
+   int m_iTurnPort;
+   std::string m_strTurnUsername;
+   std::string m_strTurnPassword;
+#endif
 
 private: // Sending related data
    CSndBuffer* m_pSndBuffer;                    // Sender buffer

--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -95,6 +95,14 @@ public:
    // Specify whether this agent is in controlling mode.
    void setControllingMode(bool controlling);
 
+   // Configure optional STUN/TURN services prior to opening the agent.
+   void setStunServer(const std::string& server, guint port);
+   void clearStunServer();
+   void setTurnRelay(const std::string& server, guint port,
+                     const std::string& username, const std::string& password,
+                     NiceRelayType type = NICE_RELAY_TYPE_TURN_UDP);
+   void clearTurnRelay();
+
 private:
    struct SendRequest
    {
@@ -186,6 +194,16 @@ private:
    mutable GCond  m_CloseCond;
    mutable bool   m_bClosing;
    mutable guint  m_ActiveSends;
+
+   bool           m_bHasStunServer;
+   std::string    m_StunServer;
+   guint          m_StunPort;
+   bool           m_bHasTurnRelay;
+   std::string    m_TurnServer;
+   guint          m_TurnPort;
+   std::string    m_TurnUsername;
+   std::string    m_TurnPassword;
+   NiceRelayType  m_TurnType;
 
    static NiceAgentSendFunc s_SendFunc;
    static gsize s_DebugInitToken;

--- a/src/udt.h
+++ b/src/udt.h
@@ -359,6 +359,9 @@ UDT_API int getICEInfo(UDTSOCKET u, std::string& ufrag, std::string& pwd,
                        std::vector<std::string>& candidates);
 UDT_API int setICEInfo(UDTSOCKET u, const std::string& ufrag, const std::string& pwd,
                        const std::vector<std::string>& candidates);
+UDT_API int setICESTUNServer(UDTSOCKET u, const std::string& server, int port);
+UDT_API int setICETURNServer(UDTSOCKET u, const std::string& server, int port,
+                             const std::string& username, const std::string& password);
 #endif
 UDT_API UDTSTATUS getsockstate(UDTSOCKET u);
 


### PR DESCRIPTION
## Summary
- allow `CNiceChannel` instances to remember STUN and TURN settings and apply them to the libnice agent before gathering
- plumb new `UDT::setICESTUNServer` / `UDT::setICETURNServer` entry points through CUDT so sockets can configure the relay services before `getICEInfo`
- update the shared sample helpers, CLI tools, and README to document the new STUN/TURN options

## Testing
- make *(fails: missing gst/app/app.h when building GStreamer samples)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbb60ffdc832c92d3131053ab52d7