### PR TITLE
Guard NICE_CHECK_VERSION usage in nice_channel

### DIFF
--- a/src/nice_channel.cpp
+++ b/src/nice_channel.cpp
@@ -3,6 +3,7 @@
 #include "nice_channel.h"
 #include <nice/agent.h>
 #include <nice/address.h>
+#include <nice/version.h>
 #include <cstring>
 #include <cerrno>
 #include <cstdarg>
@@ -13,8 +14,12 @@
 #include <winsock2.h>
 #endif
 
-#if defined(NICE_CHECK_VERSION) && NICE_CHECK_VERSION(0, 1, 18)
+#ifdef NICE_CHECK_VERSION
+#if NICE_CHECK_VERSION(0, 1, 18)
 #define POLEIS_NICE_HAS_STUN_SERVER_HELPER 0
+#else
+#define POLEIS_NICE_HAS_STUN_SERVER_HELPER 1
+#endif
 #else
 #define POLEIS_NICE_HAS_STUN_SERVER_HELPER 1
 #endif


### PR DESCRIPTION
## Summary
- include <nice/version.h> so NICE_CHECK_VERSION is available before use
- nest the preprocessor guards to avoid invoking NICE_CHECK_VERSION when it is undefined and to disable the STUN helper on libnice >= 0.1.18

## Testing
- make *(fails: missing gst/app/app.h)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd15a7690832c936544db93530c8b