### PR TITLE
Restart libnice candidate gathering after late ICE configuration

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -53,8 +53,11 @@ sample `appniceclient` and `appniceserver` programs output these fields on a
 single line by concatenating length-prefixed strings (for example,
 `4:abcd10:passphrase...`). Copy the full line and provide the remote peer's line
 when prompted. Applications may configure optional STUN and TURN services via
-`UDT::setICESTUNServer()` and `UDT::setICETURNServer()` prior to requesting ICE
-information. Passing an empty server string disables the associated relay.
+`UDT::setICESTUNServer()` and `UDT::setICETURNServer()` before or after
+requesting ICE information. Passing an empty server string disables the
+associated relay. If these setters are called after a channel has already been
+opened, the library automatically restarts candidate gathering so the updated
+configuration takes effect.
 Call `UDT::setICEPortRange(min_port, max_port)` before binding or requesting ICE
 information to constrain the local UDP ports used for gathered candidates;
 specify `(0, 0)` to return to the default libnice behavior. The `appnice*` and

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2423,6 +2423,12 @@ int CUDT::setICESTUNServer(UDTSOCKET u, const std::string& server, int port)
          if (udt->m_pSndQueue && udt->m_pSndQueue->m_pChannel)
             udt->m_pSndQueue->m_pChannel->setStunServer(udt->m_strStunServer, udt->m_iStunPort);
       }
+
+      if (udt->m_pSndQueue && udt->m_pSndQueue->m_pChannel)
+      {
+         if (!udt->m_pSndQueue->m_pChannel->restartCandidateGathering())
+            throw CUDTException(3, 1, 0);
+      }
       return 0;
    }
    catch (CUDTException e)
@@ -2468,6 +2474,12 @@ int CUDT::setICETURNServer(UDTSOCKET u, const std::string& server, int port,
             udt->m_pSndQueue->m_pChannel->setTurnRelay(udt->m_strTurnServer, udt->m_iTurnPort,
                                                        udt->m_strTurnUsername, udt->m_strTurnPassword);
          }
+      }
+
+      if (udt->m_pSndQueue && udt->m_pSndQueue->m_pChannel)
+      {
+         if (!udt->m_pSndQueue->m_pChannel->restartCandidateGathering())
+            throw CUDTException(3, 1, 0);
       }
       return 0;
    }

--- a/src/nice_channel.h
+++ b/src/nice_channel.h
@@ -103,6 +103,11 @@ public:
                      NiceRelayType type = NICE_RELAY_TYPE_TURN_UDP);
    void clearTurnRelay();
 
+   // Restart candidate gathering after ICE configuration changes. Returns
+   // true if a new gathering cycle was successfully kicked off (or no agent
+   // is currently active), and false if libnice rejected the request.
+   bool restartCandidateGathering();
+
    // Restrict local candidates to the provided inclusive port range.
    // Specify (0, 0) to clear the restriction and use libnice defaults.
    void setPortRange(guint min_port, guint max_port);


### PR DESCRIPTION
## Summary
- add a CNiceChannel helper that restarts candidate gathering after ICE configuration changes
- call the helper from the STUN and TURN setters so late configuration re-gathers candidates
- document that STUN/TURN updates applied after opening will trigger a fresh gathering round

## Testing
- not run (libnice dependency unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d00783ba00832cba2ea691145d6cfd